### PR TITLE
feat: 阻止全屏时使用`Enter`跳过赞助片段时播放器默认聚焦到弹幕输入框的行为

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -2694,6 +2694,21 @@ function hotkeyListener(e: KeyboardEvent): void {
     if (keybindEquals(key, skipKey)) {
         if (activeSkipKeybindElement) {
             activeSkipKeybindElement.toggleSkip.call(activeSkipKeybindElement);
+
+            /*
+             * b站视频播放器全屏或网页全屏时，快捷键`Enter`会聚焦到弹幕输入框
+             * 这里阻止了使用`Enter`跳过赞助片段时播放器的默认行为
+             */
+            if (key.key === 'Enter') {
+                const currentTime: number | null = document.querySelector<HTMLVideoElement>(".bpx-player-video-wrap video")?.currentTime ?? null;
+                if (currentTime) {
+                    const inSponsorRange = sponsorTimes.some(({segment: [start, end]}) => start <= currentTime && end >= currentTime);
+                    if (inSponsorRange) {
+                        utils.biliBiliPlayerDanmakuInputBlur();
+                    }
+                }
+
+            }
         }
 
         return;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -278,4 +278,8 @@ export default class Utils {
 
         Config.forceLocalUpdate("downvotedSegments");
     }
+
+    biliBiliPlayerDanmakuInputBlur() {
+        setTimeout(() => document.querySelector<HTMLInputElement>("input.bpx-player-dm-input")?.blur(), 0);
+    }
 }


### PR DESCRIPTION
不登录发不了弹幕，登录才能复现

阻止聚焦弹幕框，避免全屏按默认快捷键`Enter`跳过赞助片段时，视频不会自动隐藏界面栏目