### PR TITLE
Feat: if unskip, switch to manual skip

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1931,11 +1931,17 @@ function sendTelemetryAndCount(skippingSegments: SponsorTime[], secondsSkipped: 
 
 //skip from the start time to the end time for a certain index sponsor time
 function skipToTime({ v, skipTime, skippingSegments, openNotice, forceAutoSkip, unskipTime }: SkipToTimeParams): void {
-    if (Config.config.disableSkipping || sessionStorage.getItem("SKIPPING") === "false")
-        return sessionStorage.setItem("SKIPPING", "null");
+    if (Config.config.disableSkipping) return;
 
-    // There will only be one submission if it is manual skip
-    const autoSkip: boolean = forceAutoSkip || shouldAutoSkip(skippingSegments[0]);
+    let autoSkip: boolean;
+    if (sessionStorage.getItem("SKIPPING") === "false") {
+        sessionStorage.setItem("SKIPPING", "null");
+        autoSkip = false;
+    } else {
+        // There will only be one submission if it is manual skip
+        autoSkip = forceAutoSkip || shouldAutoSkip(skippingSegments[0]);
+    }
+
     const isSubmittingSegment = sponsorTimesSubmitting.some((time) => time.segment === skippingSegments[0].segment);
 
     if ((autoSkip || isSubmittingSegment) && v.currentTime !== skipTime[1]) {


### PR DESCRIPTION
- [X] 我同意我的所有贡献将以GPL-3.0协议开源。

***
在提前显示的跳过弹窗选择`取消跳过`时 会将剩下的逻辑return掉 导致在片段中间想跳过时只能去点进度条
这个将选择`取消跳过`后把这个片段临时变为手动跳过 手动跳过的弹窗是全程覆盖片段的 可以避免上面的情况发生