### PR TITLE
Fix: Incorrect element selection for “mainPageRecommendation”

### DIFF
--- a/src/thumbnail-utils/thumbnails.ts
+++ b/src/thumbnail-utils/thumbnails.ts
@@ -254,6 +254,9 @@ function hideVideoCard(thumbnail: HTMLElement, containerType: string) {
         if (Config.config.fullVideoLabelsOnThumbnailsMode === HideFullVideoLabels.SolidCover) {
             mask.style.backgroundColor = "var(--graph_bg_regular)";
             mask.style.pointerEvents = "all";
+        } else if (Config.config.fullVideoLabelsOnThumbnailsMode === HideFullVideoLabels.BlurAlways) {
+            mask.style.backdropFilter = "blur(8px)";
+            mask.style.pointerEvents = "all";
         } else {
             mask.style.backdropFilter = "blur(8px)";
         }


### PR DESCRIPTION
- [X] 我同意我的所有贡献将以GPL-3.0协议开源。

***
#211 

c5f9d4bb250abb7cde5d48b0a8bee4adfdb19bdf
调整`mainPageRecommendation`的`parentNode`选择节点在不同的视频卡片上选择正确的元素
<img width="399" height="244" alt="image" src="https://github.com/user-attachments/assets/85bdfb24-fc43-4aca-ab1e-977d795a76b5" />
~~同一个界面为啥会有两种视频卡片 其中一个还只是套了个壳~~

***
b9ef88c90c4167ccde81191c8d49bc06cd3bfd2a
修复在模糊遮罩下未拦截鼠标事件