### PR TITLE
添加 macOS Safari 插件构建流水线

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 web-ext-artifacts
 .vscode/
 dist/
+safari/
 tmp/
 .DS_Store
 ci/invidious_instances.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,13 +26,14 @@
 
 1. 在项目目录下执行 `npm run build:dev` (Chrome) 或 `npm run build:dev:firefox` (Firefox)，打包开发版插件。
 
-    也可以执行 `npm run build` 或者 `npm run build:firefox` 打包发行版插件，
+    也可以执行 `npm run build`、`npm run build:firefox` 或 `npm run build:safari` 打包发行版插件。
+    如果要生成 macOS Safari 可直接用的 Xcode 工程，执行 `npm run build:safari:macos`。
 
 1. 打包好的程序会输出在 `dist/` 文件夹下，你可以直接把生成的文件直接[加载到Chrome浏览器中](https://developer.chrome.com/docs/extensions/mv3/getstarted/#manifest)或者[压缩后加载到火狐浏览器中](https://developer.mozilla.org/docs/Tools/about:debugging#loading_a_temporary_extension)。
+   Safari 的 `npm run build:safari:macos` 会在项目根目录生成 `safari/` Xcode 工程。
 
 ## 开发和测试
 
 执行 `npm run dev` (Chrome) 或者 `npm run dev:firefox` (火狐)，npm 会打开一个安装好测试版插件的浏览器窗口，并且支持代码修改热加载。这里使用了[`web-ext run`](https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#commands)。
 
 插件有可能在初次打开的时候不正常加载。如果你发现有问题，可以打开浏览器的插件管理，并手动重新加载插件。
-

--- a/README.md
+++ b/README.md
@@ -45,6 +45,33 @@
 
     1. 打开浏览器的插件管理页面，启用“开发者模式”，点击`加载已解压的拓展程序`，选择刚刚下载解压的插件文件夹，就可以完成安装。
 
+## macOS Safari 安装（源码构建）
+
+Safari 版本通过 Safari Web Extension 打包。项目已提供一键脚本：
+
+```bash
+# 先准备配置文件和依赖
+cp config.json.example config.json
+npm ci
+
+# 构建 Safari 扩展并生成 macOS Xcode 工程
+npm run build:safari:macos
+```
+
+默认会在项目根目录生成 `safari/` Xcode 工程。然后：
+
+1. 使用 Xcode 打开 `safari/` 工程并编译运行。
+1. 打开 Safari -> 设置 -> 扩展，启用对应扩展。
+
+可选环境变量（用于自定义工程信息）：
+
+```bash
+BSB_SAFARI_APP_NAME="小电视空降助手" \
+BSB_SAFARI_BUNDLE_ID="top.bsbsb.safari" \
+BSB_SAFARI_PROJECT_DIR="safari" \
+npm run build:safari:macos
+```
+
 # 功能
 
 ## 使用说明

--- a/manifest/safari-manifest-extra.json
+++ b/manifest/safari-manifest-extra.json
@@ -1,0 +1,146 @@
+{
+  "manifest_version": 2,
+  "permissions": [
+    "storage",
+    "scripting",
+    "https://*.bilibili.com/*",
+    "http://*.bsbsb.top/*"
+  ],
+  "optional_permissions": [
+    "*://*/*",
+    "webNavigation"
+  ],
+  "content_scripts": [
+    {
+      "run_at": "document_start",
+      "matches": [
+        "https://*.bilibili.com/*"
+      ],
+      "exclude_matches": [
+        "https://live.bilibili.com/*"
+      ],
+      "all_frames": true,
+      "js": [
+        "./js/content.js"
+      ],
+      "css": [
+        "content.css",
+        "shared.css"
+      ]
+    }
+  ],
+  "background": {
+    "scripts": [
+      "./js/background.js"
+    ],
+    "persistent": false
+  },
+  "browser_action": {
+    "default_title": "SponsorBlock",
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/IconSponsorBlocker16px.png",
+      "32": "icons/IconSponsorBlocker32px.png",
+      "64": "icons/IconSponsorBlocker64px.png",
+      "128": "icons/IconSponsorBlocker128px.png"
+    },
+    "theme_icons": [
+      {
+        "light": "icons/IconSponsorBlocker16px.png",
+        "dark": "icons/IconSponsorBlocker16px.png",
+        "size": 16
+      },
+      {
+        "light": "icons/IconSponsorBlocker32px.png",
+        "dark": "icons/IconSponsorBlocker32px.png",
+        "size": 32
+      },
+      {
+        "light": "icons/IconSponsorBlocker64px.png",
+        "dark": "icons/IconSponsorBlocker64px.png",
+        "size": 64
+      },
+      {
+        "light": "icons/IconSponsorBlocker128px.png",
+        "dark": "icons/IconSponsorBlocker128px.png",
+        "size": 128
+      },
+      {
+        "light": "icons/IconSponsorBlocker256px.png",
+        "dark": "icons/IconSponsorBlocker256px.png",
+        "size": 256
+      },
+      {
+        "light": "icons/IconSponsorBlocker512px.png",
+        "dark": "icons/IconSponsorBlocker512px.png",
+        "size": 512
+      },
+      {
+        "light": "icons/IconSponsorBlocker1024px.png",
+        "dark": "icons/IconSponsorBlocker1024px.png",
+        "size": 1024
+      }
+    ]
+  },
+  "web_accessible_resources": [
+    "icons/LogoSponsorBlocker256px.png",
+    "icons/IconSponsorBlocker256px.png",
+    "icons/PlayerStartIconSponsorBlocker.svg",
+    "icons/PlayerStopIconSponsorBlocker.svg",
+    "icons/PlayerUploadIconSponsorBlocker.svg",
+    "icons/PlayerUploadFailedIconSponsorBlocker.svg",
+    "icons/PlayerCancelSegmentIconSponsorBlocker.svg",
+    "icons/clipboard.svg",
+    "icons/settings.svg",
+    "icons/pencil.svg",
+    "icons/check.svg",
+    "icons/check-smaller.svg",
+    "icons/upvote.png",
+    "icons/downvote.png",
+    "icons/thumbs_down.svg",
+    "icons/thumbs_down_locked.svg",
+    "icons/thumbs_up.svg",
+    "icons/help.svg",
+    "icons/report.png",
+    "icons/close.png",
+    "icons/skipIcon.svg",
+    "icons/refresh.svg",
+    "icons/beep.ogg",
+    "icons/pause.svg",
+    "icons/stop.svg",
+    "icons/skip.svg",
+    "icons/heart.svg",
+    "icons/visible.svg",
+    "icons/not_visible.svg",
+    "icons/sort.svg",
+    "icons/money.svg",
+    "icons/segway.png",
+    "icons/close-smaller.svg",
+    "icons/right-arrow.svg",
+    "icons/campaign.svg",
+    "icons/star.svg",
+    "icons/lightbulb.svg",
+    "icons/bolt.svg",
+    "icons/stopwatch.svg",
+    "icons/music-note.svg",
+    "icons/import.svg",
+    "icons/export.svg",
+    "icons/PlayerInfoIconSponsorBlocker.svg",
+    "icons/PlayerDeleteIconSponsorBlocker.svg",
+    "icons/thumbs_up_blue.svg",
+    "icons/thumbs_down_blue.svg",
+    "icons/oldIcon/PlayerStartIconSponsorBlocker.svg",
+    "icons/oldIcon/PlayerStopIconSponsorBlocker.svg",
+    "icons/oldIcon/PlayerUploadIconSponsorBlocker.svg",
+    "icons/oldIcon/PlayerUploadFailedIconSponsorBlocker.svg",
+    "icons/oldIcon/PlayerCancelSegmentIconSponsorBlocker.svg",
+    "icons/oldIcon/PlayerInfoIconSponsorBlocker.svg",
+    "icons/oldIcon/PlayerDeleteIconSponsorBlocker.svg",
+    "icons/oldIcon/skipIcon.svg",
+    "popup.html",
+    "popup.css",
+    "content.css",
+    "shared.css",
+    "js/document.js"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "build:chrome": "webpack --env browser=chrome --config webpack/webpack.prod.js",
     "build:firefox": "webpack --env browser=firefox --config webpack/webpack.prod.js",
     "build:safari": "webpack --env browser=safari --config webpack/webpack.prod.js",
+    "build:safari:macos": "bash ./scripts/build-safari-macos.sh",
     "build:edge": "webpack --env browser=edge --config webpack/webpack.prod.js",
     "build:dev": "npm run build:dev:chrome",
     "build:dev:chrome": "webpack --env browser=chrome --config webpack/webpack.dev.js",

--- a/scripts/build-safari-macos.sh
+++ b/scripts/build-safari-macos.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v xcrun >/dev/null 2>&1; then
+    echo "error: xcrun 未安装。请先安装 Xcode 或 Xcode Command Line Tools。"
+    exit 1
+fi
+
+APP_NAME="${BSB_SAFARI_APP_NAME:-BilibiliSponsorBlock}"
+BUNDLE_ID="${BSB_SAFARI_BUNDLE_ID:-top.bsbsb.BilibiliSponsorBlock}"
+PROJECT_DIR="${BSB_SAFARI_PROJECT_DIR:-safari}"
+
+npm run build:safari
+
+xcrun safari-web-extension-converter \
+    dist \
+    --project-location "$PROJECT_DIR" \
+    --app-name "$APP_NAME" \
+    --bundle-identifier "$BUNDLE_ID" \
+    --swift \
+    --macos-only \
+    --copy-resources \
+    --no-open \
+    --no-prompt \
+    --force
+
+echo "Safari macOS 工程已生成：$PROJECT_DIR"
+echo "下一步：用 Xcode 打开该工程，选择 Mac target 后 Build/Run。"

--- a/webpack/webpack.manifest.js
+++ b/webpack/webpack.manifest.js
@@ -5,9 +5,10 @@ const path = require("path");
 const { validate } = require("schema-utils");
 const fs = require("fs");
 
-const manifest = require("../manifest/manifest.json");
+const baseManifest = require("../manifest/manifest.json");
 const firefoxManifestExtra = require("../manifest/firefox-manifest-extra.json");
 const chromeManifestExtra = require("../manifest/chrome-manifest-extra.json");
+const safariManifestExtra = require("../manifest/safari-manifest-extra.json");
 
 // schema for options object
 const schema = {
@@ -35,10 +36,13 @@ class BuildManifest {
     apply() {
         const distFolder = path.resolve(__dirname, "../dist/");
         const distManifestFile = path.resolve(distFolder, "manifest.json");
+        const manifest = JSON.parse(JSON.stringify(baseManifest));
 
         // Add missing manifest elements
         if (this.options.browser.toLowerCase() === "firefox") {
             mergeObjects(manifest, firefoxManifestExtra);
+        } else if (this.options.browser.toLowerCase() === "safari") {
+            mergeObjects(manifest, safariManifestExtra);
         } else if (
             this.options.browser.toLowerCase() === "chrome" ||
             this.options.browser.toLowerCase() === "chromium" ||


### PR DESCRIPTION
- [x] 我同意我的所有贡献将以GPL-3.0协议开源。

***
改了 7 个文件，新增 2 个文件：

  1. manifest/safari-manifest-extra.json（新增）
     为 Safari 准备完整的 MV2 扩展字段（permissions、optional_permissions、content_scripts、background、browser_action、web_accessible_resources）。
  2. webpack/webpack.manifest.js
     修复构建逻辑：browser=safari 时会合并 Safari 专用 manifest；并且把基础 manifest 做深拷贝，避免多次构建时被污染。
  3. scripts/build-safari-macos.sh（新增）
     新增一键脚本：先 npm run build:safari，再调用
     xcrun safari-web-extension-converter 生成 macOS Safari 的 Xcode 工程。
  4. package.json
     新增脚本：
     "build:safari:macos": "bash ./scripts/build-safari-macos.sh"
  5. .gitignore
     新增忽略目录：safari/（避免把生成的 Xcode 工程提交到仓库）。
  6. README.md
     新增 “macOS Safari 安装（源码构建）” 章节，包含完整命令和可选环境变量说明。
  7. CONTRIBUTING.md
     补充 Safari 构建说明：build:safari 和 build:safari:macos 的用途与输出位置。

---
在safari（26.3）上测试，在呼出弹窗时失败，跳过片段和视频种类标记均无问题，上传功能暂未测试，后续可以新增CI。
<img width="856" height="92" alt="CleanShot 2026-02-19 at 14 58 49@2x" src="https://github.com/user-attachments/assets/ab62388a-9bf4-40c9-aa4b-17eca5e0602d" />
