### PR TITLE
fix: solve message port closed issue caused by async messageListener

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -280,11 +280,11 @@ const manualSkipPercentCount = 0.5;
 //get messages from the background script and the popup
 chrome.runtime.onMessage.addListener(messageListener);
 
-async function messageListener(
+function messageListener(
     request: Message,
     sender: unknown,
     sendResponse: (response: MessageResponse) => void
-): Promise<void | boolean> {
+): void | boolean {
     //messages from popup script
     switch (request.message) {
         case "update":
@@ -322,20 +322,21 @@ async function messageListener(
             popupInitialised = true;
             break;
         case "getVideoID":
-            {
+            (async () => {
                 let id = getVideoID();
                 if (!id) {
                     id = await getBilibiliVideoID();
-                    if (id) {
-                        await videoIDChange();
-                    }
+                    if (id) await videoIDChange();
                 }
-                sendResponse({
-                    videoID: id,
-                });
-            }
-
-            break;
+                return {
+                    videoID: id
+                };
+            })()
+            .then(sendResponse)
+            .catch(e => {
+                console.error('get video id failed: ', e)
+            })
+            return true;
         case "getChannelID":
             sendResponse({
                 channelID: getChannelIDInfo().id,
@@ -403,7 +404,7 @@ async function messageListener(
             selectSegment(request.UUID);
             break;
         case "submitVote":
-            vote(request.type, request.UUID).then((response) => sendResponse(response));
+            vote(request.type, request.UUID).then(sendResponse);
             return true;
         case "hideSegment":
             utils.getSponsorTimeFromUUID(sponsorTimes, request.UUID).hidden = request.type;

--- a/src/popup/PopupMessageHandler.ts
+++ b/src/popup/PopupMessageHandler.ts
@@ -15,9 +15,9 @@ export class MessageHandler {
         if (this.messageListener) {
             this.messageListener(request, null, callback);
         } else if (chrome.tabs) {
-            chrome.tabs.sendMessage(id, request, callback);
+            void chrome.tabs.sendMessage(id, request, callback);
         } else {
-            chrome.runtime.sendMessage({ message: "tabs", data: request }, callback);
+            void chrome.runtime.sendMessage({ message: "tabs", data: request }, callback);
         }
     }
 

--- a/src/popup/VideoInfo/PopupSegment.tsx
+++ b/src/popup/VideoInfo/PopupSegment.tsx
@@ -32,7 +32,7 @@ class PopupSegment extends React.Component<PopupSegmentProps, PopupSegmentState>
         };
     }
 
-    private extracInfo(): string {
+    private extraInfo(): string {
         if (this.state.hidden === SponsorHideType.Downvoted) {
             //this one is downvoted
             return " (" + chrome.i18n.getMessage("hiddenDueToDownvote") + ")";
@@ -150,7 +150,7 @@ class PopupSegment extends React.Component<PopupSegmentProps, PopupSegmentState>
                                 className="dot sponsorTimesCategoryColorCircle"
                                 style={{ backgroundColor: Config.config.barTypes[category]?.color }}
                             ></span>
-                            <span className="summaryLabel">{shortCategoryName(category) + this.extracInfo()}</span>
+                            <span className="summaryLabel">{shortCategoryName(category) + this.extraInfo()}</span>
                         </div>
                         <div style={{ margin: "5px" }}>{this.segmentFromToTime()}</div>
                     </summary>

--- a/src/popup/VideoInfo/VideoInfo.tsx
+++ b/src/popup/VideoInfo/VideoInfo.tsx
@@ -21,9 +21,7 @@ interface VideoInfoState {
     loading: boolean;
     videoFound: boolean;
     loadedMessage: string;
-
     importInputOpen: boolean;
-
     downloadedTimes: SponsorTime[];
     currentTime: number;
 }
@@ -47,7 +45,7 @@ class VideoInfo extends React.Component<VideoInfoProps, VideoInfoState> {
     private lastStartLoadingTime = performance.now();
 
     startLoading() {
-        this.setState({ loading: true });
+        this.setState((prev) => ({...prev, loading: true}));
         this.lastStartLoadingTime = performance.now();
         if (this.stopLoadingTimeout) {
             clearTimeout(this.stopLoadingTimeout);
@@ -58,23 +56,23 @@ class VideoInfo extends React.Component<VideoInfoProps, VideoInfoState> {
         const timeSinceStart = performance.now() - this.lastStartLoadingTime;
         if (timeSinceStart < BUTTON_REFRESH_DURATION) {
             this.stopLoadingTimeout = setTimeout(() => {
-                this.setState({ loading: false });
+                this.setState((prev) => ({...prev, loading: false}));
                 this.stopLoadingTimeout = null;
             }, BUTTON_REFRESH_DURATION - timeSinceStart);
         } else {
-            this.setState({ loading: false });
+            this.setState((prev) => ({...prev, loading: false}));
         }
     }
 
     displayNoVideo() {
         // 无法找到视频，不是播放页面
-        this.setState({ videoFound: false });
+        this.setState(prev => ({...prev, videoFound: false}));
         this.stopLoading();
     }
 
     displayVideoWithMessage(message: string = chrome.i18n.getMessage("sponsorFound")) {
         // 可以找到视频ID
-        this.setState({ videoFound: true, loadedMessage: message });
+        this.setState(prev => ({...prev, videoFound: true, loadedMessage: message}));
         this.stopLoading();
     }
 
@@ -94,7 +92,7 @@ class VideoInfo extends React.Component<VideoInfoProps, VideoInfoState> {
     }
 
     private toggleImportInput() {
-        this.setState({ importInputOpen: !this.state.importInputOpen });
+        this.setState(prev => ({...prev, importInputOpen: !this.state.importInputOpen}));
     }
 
     private async importSegments() {
@@ -105,20 +103,19 @@ class VideoInfo extends React.Component<VideoInfoProps, VideoInfoState> {
             data: text,
         });
 
-        this.setState({ importInputOpen: false });
+        this.setState(prev => ({...prev, importInputOpen: false}));
     }
 
     private exportSegments() {
         this.props.copyToClipboard(exportTimes(this.state.downloadedTimes));
-        this.props.messageApi.success(chrome.i18n.getMessage(`CopiedExclamation`));
+        void this.props.messageApi.success(chrome.i18n.getMessage(`CopiedExclamation`));
     }
 
     private computeIndicatorText() {
-        let text = "";
+        let text: string;
         if (this.state.loading) {
             text = chrome.i18n.getMessage("Loading");
-        }
-        if (this.state.videoFound) {
+        } else if (this.state.videoFound) {
             text = this.state.loadedMessage;
         } else {
             text = chrome.i18n.getMessage("noVideoID");
@@ -139,7 +136,7 @@ class VideoInfo extends React.Component<VideoInfoProps, VideoInfoState> {
             .sort((a, b) => a.segment[1] - b.segment[1])
             .sort((a, b) => a.segment[0] - b.segment[0]);
 
-        this.setState({ downloadedTimes: downloadedTimes, currentTime: time });
+        this.setState(prev => ({...prev, downloadedTimes: downloadedTimes, currentTime: time}));
     }
 
     private SegmentList(): React.ReactNode[] {


### PR DESCRIPTION
1. 排查PopupSegment里的vote()调用后没有触发toast的问题时，发现content.ts里的messageListener之前被改成了async，查了下这样会造成'The message port closed before a response was received'，导致vote()里拿不到response，就改回sync；
2. 把case "getVideoID"用async IIFE改写了下，不再依赖async的messageListener；
3. 排查过程中发现content.ts有重复注入的情况，导致里面的messageListener是有重复监听的，比如submitVote，想问下是不是特意如此设计的，

- [x] 我同意我的所有贡献将以GPL-3.0协议开源。

***
