### PR TITLE
refactor: 渐进式拆分 content.ts 为模块化架构

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -5,7 +5,8 @@ import {
     getPageLoaded,
     setupPageLoadingListener,
 } from "./content/state";
-import { danmakuForSkip, initDanmakuSkip } from "./content/danmakuSkip";
+import { initDanmakuSkip } from "./content/danmakuSkip";
+import { initVideoListeners, setupVideoListeners } from "./content/videoListeners";
 import {
     checkPreviewbarState,
     createPreviewBar,
@@ -16,8 +17,6 @@ import {
     updatePreviewBar,
 } from "./content/previewBarManager";
 import {
-    cancelSponsorSchedule,
-    clearWaitingTime,
     getVirtualTime,
     initSkipScheduler,
     isSegmentMarkedNearCurrentTime,
@@ -27,8 +26,6 @@ import {
     startSkipScheduleCheckingForStartSponsors,
     startSponsorSchedule,
     unskipSponsorTime,
-    updateVirtualTime,
-    updateWaitingTime,
 } from "./content/skipScheduler";
 import { initMessageHandler, setupMessageListener } from "./content/messageHandler";
 import { addHotkeyListener, initHotkeyHandler, seekFrameByKeyPressListener } from "./content/hotkeyHandler";
@@ -70,7 +67,7 @@ import {
 } from "./types";
 import Utils from "./utils";
 import { waitFor } from "./utils/";
-import { addCleanupListener, cleanPage } from "./utils/cleanup";
+import { cleanPage } from "./utils/cleanup";
 import { GenericUtils } from "./utils/genericUtils";
 import { logDebug } from "./utils/logger";
 import { getControls, getProgressBar } from "./utils/pageUtils";
@@ -122,6 +119,8 @@ initDanmakuSkip({
 initHotkeyHandler({ startOrEndTimingNewSegment, submitSegments, openSubmissionMenu, previewRecentSegment });
 
 initPreviewBarManager({ voteAsync, updateVisibilityOfPlayerControlsButton });
+
+initVideoListeners({ updateVisibilityOfPlayerControlsButton });
 
 setupVideoModule({ videoIDChange, channelIDChange, resetValues, videoElementChange });
 
@@ -287,220 +286,6 @@ async function videoIDChange(): Promise<void> {
     ) CommentListener();
 }
 
-/**
- * Triggered every time the video duration changes.
- * This happens when the resolution changes or at random time to clear memory.
- */
-function durationChangeListener(): void {
-    updatePreviewBar();
-}
-
-/**
- * Triggered once the video is ready.
- * This is mainly to attach to embedded players who don't have a video element visible.
- */
-function videoOnReadyListener(): void {
-    createPreviewBar();
-    updatePreviewBar();
-    updateVisibilityOfPlayerControlsButton();
-}
-
-
-let playbackRateCheckInterval: NodeJS.Timeout | null = null;
-let lastPlaybackSpeed = 1;
-let setupVideoListenersFirstTime = true;
-function setupVideoListeners(video: HTMLVideoElement) {
-    if (!video) return; // Maybe video became invisible
-
-    //wait until it is loaded
-    video.addEventListener("loadstart", videoOnReadyListener);
-    video.addEventListener("durationchange", durationChangeListener);
-
-    if (setupVideoListenersFirstTime) {
-        addCleanupListener(() => {
-            video.removeEventListener("loadstart", videoOnReadyListener);
-            video.removeEventListener("durationchange", durationChangeListener);
-        });
-    }
-
-    if (!Config.config.disableSkipping) {
-        danmakuForSkip();
-
-        contentState.switchingVideos = false;
-
-        let startedWaiting = false;
-        let lastPausedAtZero = true;
-
-        const rateChangeListener = () => {
-            updateVirtualTime();
-            clearWaitingTime();
-
-            startSponsorSchedule();
-        };
-        video.addEventListener("ratechange", rateChangeListener);
-        // Used by videospeed extension (https://github.com/igrigorik/videospeed/pull/740)
-        video.addEventListener("videoSpeed_ratechange", rateChangeListener);
-
-        const playListener = () => {
-            // If it is not the first event, then the only way to get to 0 is if there is a seek event
-            // This check makes sure that changing the video resolution doesn't cause the extension to think it
-            // gone back to the begining
-            if (video.readyState <= HTMLMediaElement.HAVE_CURRENT_DATA && video.currentTime === 0) return;
-
-            updateVirtualTime();
-
-            if (contentState.switchingVideos || lastPausedAtZero) {
-                contentState.switchingVideos = false;
-                logDebug("Setting switching videos to false");
-
-                // If already segments loaded before video, retry to skip starting segments
-                if (contentState.sponsorTimes) startSkipScheduleCheckingForStartSponsors();
-            }
-
-            lastPausedAtZero = false;
-
-            // Make sure it doesn't get double called with the playing event
-            if (
-                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
-                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
-            ) {
-                contentState.lastCheckTime = Date.now();
-                contentState.lastCheckVideoTime = video.currentTime;
-
-                startSponsorSchedule();
-            }
-        };
-        video.addEventListener("play", playListener);
-
-        const playingListener = () => {
-            updateVirtualTime();
-            lastPausedAtZero = false;
-
-            if (startedWaiting) {
-                startedWaiting = false;
-                logDebug(
-                    `[SB] Playing event after buffering: ${Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
-                    (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
-                    }`
-                );
-            }
-
-            if (contentState.switchingVideos) {
-                contentState.switchingVideos = false;
-                logDebug("Setting switching videos to false");
-
-                // If already segments loaded before video, retry to skip starting segments
-                if (contentState.sponsorTimes) startSkipScheduleCheckingForStartSponsors();
-            }
-
-            // Make sure it doesn't get double called with the play event
-            if (
-                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
-                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
-            ) {
-                contentState.lastCheckTime = Date.now();
-                contentState.lastCheckVideoTime = video.currentTime;
-
-                startSponsorSchedule();
-            }
-
-            if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
-            lastPlaybackSpeed = video.playbackRate;
-
-            // Video speed controller compatibility
-            // That extension makes rate change events not propagate
-            if (document.body.classList.contains("vsc-initialized")) {
-                playbackRateCheckInterval = setInterval(() => {
-                    if ((!getVideoID() || video.paused) && playbackRateCheckInterval) {
-                        // Video is gone, stop checking
-                        clearInterval(playbackRateCheckInterval);
-                        return;
-                    }
-
-                    if (video.playbackRate !== lastPlaybackSpeed) {
-                        lastPlaybackSpeed = video.playbackRate;
-
-                        rateChangeListener();
-                    }
-                }, 2000);
-            }
-        };
-        video.addEventListener("playing", playingListener);
-
-        const seekingListener = () => {
-            contentState.lastKnownVideoTime.fromPause = false;
-
-            if (!video.paused) {
-                // Reset lastCheckVideoTime
-                contentState.lastCheckTime = Date.now();
-                contentState.lastCheckVideoTime = video.currentTime;
-
-                updateVirtualTime();
-                clearWaitingTime();
-
-                // Sometimes looped videos loop back to almost zero, but not quite
-                if (video.loop && video.currentTime < 0.2) {
-                    startSponsorSchedule(false, 0);
-                } else {
-                    // Include intersecting segments so that seeking into the middle of a segment still triggers a skip
-                    startSponsorSchedule(Config.config.skipOnSeekToSegment);
-                }
-            } else {
-                updateActiveSegment(video.currentTime);
-
-                if (video.currentTime === 0) {
-                    lastPausedAtZero = true;
-                }
-            }
-        };
-        video.addEventListener("seeking", seekingListener);
-
-        const stoppedPlayback = () => {
-            // Reset lastCheckVideoTime
-            contentState.lastCheckVideoTime = -1;
-            contentState.lastCheckTime = 0;
-
-            if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
-
-            contentState.lastKnownVideoTime.videoTime = null;
-            contentState.lastKnownVideoTime.preciseTime = null;
-            updateWaitingTime();
-
-            cancelSponsorSchedule();
-        };
-        const pauseListener = () => {
-            contentState.lastKnownVideoTime.fromPause = true;
-
-            stoppedPlayback();
-        };
-        video.addEventListener("pause", pauseListener);
-        const waitingListener = () => {
-            logDebug("[SB] Not skipping due to buffering");
-            startedWaiting = true;
-
-            stoppedPlayback();
-        };
-        video.addEventListener("waiting", waitingListener);
-
-        startSponsorSchedule();
-
-        if (setupVideoListenersFirstTime) {
-            addCleanupListener(() => {
-                video.removeEventListener("play", playListener);
-                video.removeEventListener("playing", playingListener);
-                video.removeEventListener("seeking", seekingListener);
-                video.removeEventListener("ratechange", rateChangeListener);
-                video.removeEventListener("videoSpeed_ratechange", rateChangeListener);
-                video.removeEventListener("pause", pauseListener);
-                video.removeEventListener("waiting", waitingListener);
-
-                if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
-            });
-        }
-    }
-
-    setupVideoListenersFirstTime = false;
-}
 
 
 //checks if this channel is whitelisted, should be done only after the channelID has been loaded

--- a/src/content.ts
+++ b/src/content.ts
@@ -12,6 +12,7 @@ import {
     setupPageLoadingListener,
     skipBuffer,
 } from "./content/state";
+import { danmakuForSkip, initDanmakuSkip } from "./content/danmakuSkip";
 import { Message, MessageResponse, VoteResponse } from "./messageTypes";
 import advanceSkipNotice from "./render/advanceSkipNotice";
 import { CategoryPill } from "./render/CategoryPill";
@@ -109,6 +110,13 @@ if ((document.hidden && getPageType() == PageType.Video) || ([PageType.Video, Pa
 }
 
 setupPageLoadingListener();
+
+initDanmakuSkip({
+    getVirtualTime,
+    isSegmentMarkedNearCurrentTime,
+    skipToTime,
+    openSubmissionMenu,
+});
 
 setupVideoModule({ videoIDChange, channelIDChange, resetValues, videoElementChange });
 
@@ -766,94 +774,6 @@ async function startSponsorSchedule(
     }
 }
 
-function checkDanmaku(text: string, offset: number) {
-    const targetTime = parseTargetTimeFromDanmaku(text, getVirtualTime());
-    if (targetTime === null) return;
-
-    // [DEBUG]
-    // console.debug("检测到空降弹幕: ", text, "请求跳转到: ", targetTime);
-
-    const startTime = getVirtualTime() + offset;
-
-    // ignore if the time is in the past
-    if (targetTime < startTime + 5) return;
-    if (targetTime > getVideo().duration) return;
-
-    if (Config.config.checkTimeDanmakuSkip && isSegmentMarkedNearCurrentTime(startTime)) return;
-
-    const skippingSegments: SponsorTime[] = [
-        {
-            cid: getCid(),
-            actionType: ActionType.Skip,
-            segment: [startTime, targetTime],
-            source: SponsorSourceType.Danmaku,
-            UUID: generateUserID() as SegmentUUID,
-            category: "sponsor" as Category,
-        },
-    ];
-
-    setTimeout(() => {
-        skipToTime({
-            v: getVideo(),
-            skipTime: [startTime, targetTime],
-            skippingSegments,
-            openNotice: true,
-            forceAutoSkip: Config.config.enableAutoSkipDanmakuSkip,
-            unskipTime: startTime,
-        });
-        if (Config.config.enableMenuDanmakuSkip) {
-            setTimeout(() => {
-                if (!contentState.sponsorTimesSubmitting?.some((s) => s.segment[1] === skippingSegments[0].segment[1])) {
-                    contentState.sponsorTimesSubmitting.push(skippingSegments[0]);
-                }
-                openSubmissionMenu();
-            }, Config.config.skipNoticeDuration * 1000 + 500);
-        }
-    }, offset * 1000 - 100);
-}
-
-let danmakuObserver: MutationObserver = null;
-const processedDanmaku = new Set<string>();
-
-function danmakuForSkip() {
-    if (!Config.config.enableDanmakuSkip || Config.config.disableSkipping) return;
-    if (danmakuObserver) return;
-
-    const targetNode = document.querySelector(".bpx-player-row-dm-wrap"); // 选择父节点
-    const config = { attributes: true, subtree: true }; // 观察属性变化
-    const callback = (mutationsList: MutationRecord[]) => {
-        if (!Config.config.enableDanmakuSkip || Config.config.disableSkipping) return;
-        if (targetNode.classList.contains("bili-danmaku-x-paused")) return;
-        for (const mutation of mutationsList) {
-            const target = mutation.target as HTMLElement;
-            if (mutation.type === "attributes" && target.classList.contains("bili-danmaku-x-dm")) {
-                const content = mutation.target.textContent;
-                if (target.classList.contains("bili-danmaku-x-show")) {
-                    if (!content || processedDanmaku.has(content)) {
-                        continue;
-                    }
-                    processedDanmaku.add(content);
-                    const offset = target.classList.contains("bili-danmaku-x-center") ? 0.3 : 1;
-                    checkDanmaku(content, offset);
-                } else {
-                    if (!content || processedDanmaku.has(content)) {
-                        processedDanmaku.delete(content);
-                    }
-                }
-            }
-        }
-    };
-    danmakuObserver = new MutationObserver(callback);
-    danmakuObserver.observe(targetNode, config);
-    addCleanupListener(() => {
-        if (danmakuObserver) {
-            danmakuObserver.disconnect();
-            danmakuObserver = null;
-            processedDanmaku.clear();
-            return;
-        }
-    });
-}
 
 /**
  * Used on Firefox only, waits for the next animation frame until

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,15 +1,11 @@
-import SkipNoticeComponent from "./components/SkipNoticeComponent";
 import Config from "./config";
-import { keybindToString } from "./config/config";
 import { ContentContainer } from "./ContentContainerTypes";
-import { SkipButtonControlBar } from "./js-components/skipButtonControlBar";
 import {
     contentState,
     getPageLoaded,
     setupPageLoadingListener,
 } from "./content/state";
-import { initDanmakuSkip } from "./content/danmakuSkip";
-import { initVideoListeners, setupVideoListeners } from "./content/videoListeners";
+import { danmakuForSkip, initDanmakuSkip } from "./content/danmakuSkip";
 import {
     checkPreviewbarState,
     createPreviewBar,
@@ -20,6 +16,8 @@ import {
     updatePreviewBar,
 } from "./content/previewBarManager";
 import {
+    cancelSponsorSchedule,
+    clearWaitingTime,
     getVirtualTime,
     initSkipScheduler,
     isSegmentMarkedNearCurrentTime,
@@ -29,63 +27,61 @@ import {
     startSkipScheduleCheckingForStartSponsors,
     startSponsorSchedule,
     unskipSponsorTime,
+    updateVirtualTime,
+    updateWaitingTime,
 } from "./content/skipScheduler";
 import { initMessageHandler, setupMessageListener } from "./content/messageHandler";
 import { addHotkeyListener, initHotkeyHandler, seekFrameByKeyPressListener } from "./content/hotkeyHandler";
-import { VoteResponse } from "./messageTypes";
-import { CategoryPill } from "./render/CategoryPill";
-import { DescriptionPortPill } from "./render/DescriptionPortPill";
-import { CommentListener, DynamicListener } from "./render/DynamicAndCommentSponsorBlock";
-import { setMessageNotice, showMessage } from "./render/MessageNotice";
+import {
+    cancelCreatingSegment,
+    clearSponsorTimes,
+    closeInfoMenu,
+    dontShowNoticeAgain,
+    getRealCurrentTime,
+    initSegmentSubmission,
+    isSegmentCreationInProgress,
+    openInfoMenu,
+    openSubmissionMenu,
+    portVideoVote,
+    previewRecentSegment,
+    resetSponsorSubmissionNotice,
+    setupCategoryPill,
+    setupDescriptionPill,
+    setupSkipButtonControlBar,
+    sponsorsLookup,
+    startOrEndTimingNewSegment,
+    submitPortVideo,
+    submitSegments,
+    updateSegments,
+    updateSegmentSubmitting,
+    updateSponsorTimesSubmitting,
+    updateVisibilityOfPlayerControlsButton,
+    vote,
+    voteAsync,
+} from "./content/segmentSubmission";
+import { DynamicListener, CommentListener } from "./render/DynamicAndCommentSponsorBlock";
+import { setMessageNotice } from "./render/MessageNotice";
 import { PlayerButton } from "./render/PlayerButton";
-import SubmissionNotice from "./render/SubmissionNotice";
-import { getPortVideoByHash, postPortVideo, postPortVideoVote, updatePortedSegments } from "./requests/portVideo";
-import { asyncRequestToServer } from "./requests/requests";
-import { getSegmentsByVideoID } from "./requests/segments";
-import { FetchResponse } from "./requests/type/requestType";
-import { getVideoLabel } from "./requests/videoLabels";
 import { checkPageForNewThumbnails, setupThumbnailListener } from "./thumbnail-utils/thumbnailManagement";
 import {
-    ActionType,
-    BVID,
-    Category,
     ChannelIDInfo,
     ChannelIDStatus,
-    NewVideoID,
     PageType,
-    PortVideo,
-    SegmentUUID,
-    SponsorHideType,
-    SponsorSourceType,
-    SponsorTime,
-    YTID,
 } from "./types";
 import Utils from "./utils";
 import { waitFor } from "./utils/";
-import { AnimationUtils } from "./utils/animationUtils";
-import { cleanPage } from "./utils/cleanup";
-import { defaultPreviewTime } from "./utils/constants";
-import { durationEquals } from "./utils/duraionUtils";
-import { getErrorMessage, getFormattedTime } from "./utils/formating";
+import { addCleanupListener, cleanPage } from "./utils/cleanup";
 import { GenericUtils } from "./utils/genericUtils";
-import { getHash, getVideoIDHash, HashedValue } from "./utils/hash";
-import { getCidMapFromWindow } from "./utils/injectedScriptMessageUtils";
 import { logDebug } from "./utils/logger";
-import { getControls, getHashParams, getProgressBar } from "./utils/pageUtils";
-import { generateUserID } from "./utils/setup";
+import { getControls, getProgressBar } from "./utils/pageUtils";
 import {
     detectPageType,
-    getBvID,
     getChannelIDInfo,
-    getCid,
     getPageType,
     getVideo,
     getVideoID,
     setupVideoModule,
-    waitForVideo,
 } from "./utils/video";
-import { parseBvidAndCidFromVideoId } from "./utils/videoIdUtils";
-import { openWarningDialog } from "./utils/warnings";
 
 cleanPage();
 
@@ -126,8 +122,6 @@ initDanmakuSkip({
 initHotkeyHandler({ startOrEndTimingNewSegment, submitSegments, openSubmissionMenu, previewRecentSegment });
 
 initPreviewBarManager({ voteAsync, updateVisibilityOfPlayerControlsButton });
-
-initVideoListeners({ updateVisibilityOfPlayerControlsButton });
 
 setupVideoModule({ videoIDChange, channelIDChange, resetValues, videoElementChange });
 
@@ -170,6 +164,18 @@ const skipNoticeContentContainer: ContentContainer = () => ({
     getRealCurrentTime: getRealCurrentTime,
     lockedCategories: contentState.lockedCategories,
     channelIDInfo: getChannelIDInfo(),
+});
+
+initSegmentSubmission({
+    skipToTime,
+    startSponsorSchedule,
+    previewTime,
+    startSkipScheduleCheckingForStartSponsors,
+    updatePreviewBar,
+    selectSegment,
+    seekFrameByKeyPressListener,
+    playerButton,
+    skipNoticeContentContainer,
 });
 
 initSkipScheduler({
@@ -281,235 +287,219 @@ async function videoIDChange(): Promise<void> {
     ) CommentListener();
 }
 
+/**
+ * Triggered every time the video duration changes.
+ * This happens when the resolution changes or at random time to clear memory.
+ */
+function durationChangeListener(): void {
+    updatePreviewBar();
+}
+
+/**
+ * Triggered once the video is ready.
+ * This is mainly to attach to embedded players who don't have a video element visible.
+ */
+function videoOnReadyListener(): void {
+    createPreviewBar();
+    updatePreviewBar();
+    updateVisibilityOfPlayerControlsButton();
+}
 
 
-function setupSkipButtonControlBar() {
-    if (!contentState.skipButtonControlBar) {
-        contentState.skipButtonControlBar = new SkipButtonControlBar({
-            skip: (segment) =>
-                skipToTime({
-                    v: getVideo(),
-                    skipTime: segment.segment,
-                    skippingSegments: [segment],
-                    openNotice: true,
-                    forceAutoSkip: true,
-                }),
-            selectSegment,
+let playbackRateCheckInterval: NodeJS.Timeout | null = null;
+let lastPlaybackSpeed = 1;
+let setupVideoListenersFirstTime = true;
+function setupVideoListeners(video: HTMLVideoElement) {
+    if (!video) return; // Maybe video became invisible
+
+    //wait until it is loaded
+    video.addEventListener("loadstart", videoOnReadyListener);
+    video.addEventListener("durationchange", durationChangeListener);
+
+    if (setupVideoListenersFirstTime) {
+        addCleanupListener(() => {
+            video.removeEventListener("loadstart", videoOnReadyListener);
+            video.removeEventListener("durationchange", durationChangeListener);
         });
     }
 
-    contentState.skipButtonControlBar.attachToPage();
-}
+    if (!Config.config.disableSkipping) {
+        danmakuForSkip();
 
-function setupCategoryPill() {
-    if (!contentState.categoryPill) {
-        contentState.categoryPill = new CategoryPill();
-    }
+        contentState.switchingVideos = false;
 
-    contentState.categoryPill.attachToPage(voteAsync);
-}
+        let startedWaiting = false;
+        let lastPausedAtZero = true;
 
-function setupDescriptionPill() {
-    if (!contentState.descriptionPill) {
-        contentState.descriptionPill = new DescriptionPortPill(
-            getPortVideo,
-            submitPortVideo,
-            portVideoVote,
-            updateSegments,
-            sponsorsLookup
-        );
-    }
-    contentState.descriptionPill.setupDescription(getVideoID());
-}
+        const rateChangeListener = () => {
+            updateVirtualTime();
+            clearWaitingTime();
 
-async function updatePortVideoElements(newPortVideo: PortVideo) {
-    contentState.portVideo = newPortVideo;
-    // notify description pill
-    waitFor(() => contentState.descriptionPill).then(() => contentState.descriptionPill.setPortVideoData(newPortVideo));
+            startSponsorSchedule();
+        };
+        video.addEventListener("ratechange", rateChangeListener);
+        // Used by videospeed extension (https://github.com/igrigorik/videospeed/pull/740)
+        video.addEventListener("videoSpeed_ratechange", rateChangeListener);
 
-    // notify popup of port video changes
-    chrome.runtime.sendMessage({
-        message: "infoUpdated",
-        found: contentState.sponsorDataFound,
-        status: contentState.lastResponseStatus,
-        sponsorTimes: contentState.sponsorTimes,
-        portVideo: newPortVideo,
-        time: getVideo()?.currentTime ?? 0,
-    });
-}
+        const playListener = () => {
+            // If it is not the first event, then the only way to get to 0 is if there is a seek event
+            // This check makes sure that changing the video resolution doesn't cause the extension to think it
+            // gone back to the begining
+            if (video.readyState <= HTMLMediaElement.HAVE_CURRENT_DATA && video.currentTime === 0) return;
 
-async function getPortVideo(videoId: NewVideoID, bypassCache = false) {
-    const newPortVideo = await getPortVideoByHash(videoId, { bypassCache });
-    if (newPortVideo?.UUID === contentState.portVideo?.UUID) return;
-    contentState.portVideo = newPortVideo;
+            updateVirtualTime();
 
-    updatePortVideoElements(contentState.portVideo);
-}
+            if (contentState.switchingVideos || lastPausedAtZero) {
+                contentState.switchingVideos = false;
+                logDebug("Setting switching videos to false");
 
-async function submitPortVideo(ytbID: YTID): Promise<PortVideo> {
-    const newPortVideo = await postPortVideo(getVideoID(), ytbID, getVideo()?.duration);
-    contentState.portVideo = newPortVideo;
-    updatePortVideoElements(contentState.portVideo);
-    sponsorsLookup(true, true, true);
-    return newPortVideo;
-}
-
-async function portVideoVote(UUID: string, voteType: number) {
-    await postPortVideoVote(UUID, getVideoID(), voteType);
-    await getPortVideo(getVideoID(), true);
-}
-
-async function updateSegments(UUID: string): Promise<FetchResponse> {
-    const response = await updatePortedSegments(getVideoID(), UUID);
-    if (response.ok) {
-        sponsorsLookup(true, true, true);
-    }
-    return response;
-}
-
-async function sponsorsLookup(keepOldSubmissions = true, ignoreServerCache = false, forceUpdatePreviewBar = false) {
-    const videoID = getVideoID();
-    const { bvId, cid } = parseBvidAndCidFromVideoId(videoID);
-    if (!videoID) {
-        console.error("[SponsorBlock] Attempted to fetch segments with a null/undefined videoID.");
-        return;
-    }
-    if (contentState.lookupWaiting) return;
-
-    if (!getVideo()) {
-        //there is still no video here
-        await waitForVideo();
-
-        contentState.lookupWaiting = true;
-        setTimeout(() => {
-            contentState.lookupWaiting = false;
-            sponsorsLookup(keepOldSubmissions, ignoreServerCache, forceUpdatePreviewBar);
-        }, 100);
-        return;
-    }
-
-    const extraRequestData: Record<string, unknown> = {};
-    const hashParams = getHashParams();
-    if (hashParams.requiredSegment) extraRequestData.requiredSegment = hashParams.requiredSegment;
-
-    const hashPrefix = (await getVideoIDHash(videoID)).slice(0, 4) as BVID & HashedValue;
-    const segmentResponse = await getSegmentsByVideoID(videoID, extraRequestData, ignoreServerCache);
-
-    // Make sure an old pending request doesn't get used.
-    if (videoID !== getVideoID()) return;
-
-    // store last response status
-    contentState.lastResponseStatus = segmentResponse?.status;
-
-    if (segmentResponse.status === 200) {
-        // filter and refresh cid
-        let receivedSegments: SponsorTime[] = segmentResponse.segments?.filter(segment => segment.cid === cid);
-
-        const uniqueCids = new Set(segmentResponse?.segments?.filter((segment) => durationEquals(segment.videoDuration, getVideo()?.duration, 5)).map(s => s.cid));
-        console.log("unique cids from segments", uniqueCids)
-        if (uniqueCids.size > 1) {
-            const cidMap = await getCidMapFromWindow(bvId);
-            console.log("[BSB] Multiple CIDs found, using the one from the window object", cidMap);
-            if (cidMap.size == 1) {
-                receivedSegments = segmentResponse.segments?.filter(segment => uniqueCids.has(segment.cid));
-                // TOOO: inform server about cid change
-            }
-        }
-
-        if (receivedSegments && receivedSegments.length) {
-            contentState.sponsorDataFound = true;
-
-            // Check if any old submissions should be kept
-            if (contentState.sponsorTimes !== null && keepOldSubmissions) {
-                for (let i = 0; i < contentState.sponsorTimes.length; i++) {
-                    if (contentState.sponsorTimes[i].source === SponsorSourceType.Local) {
-                        // This is a user submission, keep it
-                        receivedSegments.push(contentState.sponsorTimes[i]);
-                    }
-                }
+                // If already segments loaded before video, retry to skip starting segments
+                if (contentState.sponsorTimes) startSkipScheduleCheckingForStartSponsors();
             }
 
-            const oldSegments = contentState.sponsorTimes || [];
-            contentState.sponsorTimes = receivedSegments;
+            lastPausedAtZero = false;
 
-            // Hide all submissions smaller than the minimum duration
-            if (Config.config.minDuration !== 0) {
-                for (const segment of contentState.sponsorTimes) {
-                    const duration = segment.segment[1] - segment.segment[0];
-                    if (duration > 0 && duration < Config.config.minDuration) {
-                        segment.hidden = SponsorHideType.MinimumDuration;
-                    }
-                }
-            }
-
-            if (keepOldSubmissions) {
-                for (const segment of oldSegments) {
-                    const otherSegment = contentState.sponsorTimes.find((other) => segment.UUID === other.UUID);
-                    if (otherSegment) {
-                        // If they downvoted it, or changed the category, keep it
-                        otherSegment.hidden = segment.hidden;
-                        otherSegment.category = segment.category;
-                    }
-                }
-            }
-
-            // See if some segments should be hidden
-            const downvotedData = Config.local.downvotedSegments[hashPrefix];
-            if (downvotedData) {
-                for (const segment of contentState.sponsorTimes) {
-                    const hashedUUID = await getHash(segment.UUID, 1);
-                    const segmentDownvoteData = downvotedData.segments.find((downvote) => downvote.uuid === hashedUUID);
-                    if (segmentDownvoteData) {
-                        segment.hidden = segmentDownvoteData.hidden;
-                    }
-                }
-            }
-
-            startSkipScheduleCheckingForStartSponsors();
-
-            //update the preview bar
-            //leave the type blank for now until categories are added
+            // Make sure it doesn't get double called with the playing event
             if (
-                forceUpdatePreviewBar ||
-                contentState.lastPreviewBarUpdate == getVideoID() ||
-                (contentState.lastPreviewBarUpdate == null && !isNaN(getVideo().duration))
+                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
+                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
             ) {
-                //set it now
-                //otherwise the listener can handle it
-                updatePreviewBar();
+                contentState.lastCheckTime = Date.now();
+                contentState.lastCheckVideoTime = video.currentTime;
+
+                startSponsorSchedule();
             }
+        };
+        video.addEventListener("play", playListener);
+
+        const playingListener = () => {
+            updateVirtualTime();
+            lastPausedAtZero = false;
+
+            if (startedWaiting) {
+                startedWaiting = false;
+                logDebug(
+                    `[SB] Playing event after buffering: ${Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
+                    (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
+                    }`
+                );
+            }
+
+            if (contentState.switchingVideos) {
+                contentState.switchingVideos = false;
+                logDebug("Setting switching videos to false");
+
+                // If already segments loaded before video, retry to skip starting segments
+                if (contentState.sponsorTimes) startSkipScheduleCheckingForStartSponsors();
+            }
+
+            // Make sure it doesn't get double called with the play event
+            if (
+                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
+                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
+            ) {
+                contentState.lastCheckTime = Date.now();
+                contentState.lastCheckVideoTime = video.currentTime;
+
+                startSponsorSchedule();
+            }
+
+            if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
+            lastPlaybackSpeed = video.playbackRate;
+
+            // Video speed controller compatibility
+            // That extension makes rate change events not propagate
+            if (document.body.classList.contains("vsc-initialized")) {
+                playbackRateCheckInterval = setInterval(() => {
+                    if ((!getVideoID() || video.paused) && playbackRateCheckInterval) {
+                        // Video is gone, stop checking
+                        clearInterval(playbackRateCheckInterval);
+                        return;
+                    }
+
+                    if (video.playbackRate !== lastPlaybackSpeed) {
+                        lastPlaybackSpeed = video.playbackRate;
+
+                        rateChangeListener();
+                    }
+                }, 2000);
+            }
+        };
+        video.addEventListener("playing", playingListener);
+
+        const seekingListener = () => {
+            contentState.lastKnownVideoTime.fromPause = false;
+
+            if (!video.paused) {
+                // Reset lastCheckVideoTime
+                contentState.lastCheckTime = Date.now();
+                contentState.lastCheckVideoTime = video.currentTime;
+
+                updateVirtualTime();
+                clearWaitingTime();
+
+                // Sometimes looped videos loop back to almost zero, but not quite
+                if (video.loop && video.currentTime < 0.2) {
+                    startSponsorSchedule(false, 0);
+                } else {
+                    // Include intersecting segments so that seeking into the middle of a segment still triggers a skip
+                    startSponsorSchedule(Config.config.skipOnSeekToSegment);
+                }
+            } else {
+                updateActiveSegment(video.currentTime);
+
+                if (video.currentTime === 0) {
+                    lastPausedAtZero = true;
+                }
+            }
+        };
+        video.addEventListener("seeking", seekingListener);
+
+        const stoppedPlayback = () => {
+            // Reset lastCheckVideoTime
+            contentState.lastCheckVideoTime = -1;
+            contentState.lastCheckTime = 0;
+
+            if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
+
+            contentState.lastKnownVideoTime.videoTime = null;
+            contentState.lastKnownVideoTime.preciseTime = null;
+            updateWaitingTime();
+
+            cancelSponsorSchedule();
+        };
+        const pauseListener = () => {
+            contentState.lastKnownVideoTime.fromPause = true;
+
+            stoppedPlayback();
+        };
+        video.addEventListener("pause", pauseListener);
+        const waitingListener = () => {
+            logDebug("[SB] Not skipping due to buffering");
+            startedWaiting = true;
+
+            stoppedPlayback();
+        };
+        video.addEventListener("waiting", waitingListener);
+
+        startSponsorSchedule();
+
+        if (setupVideoListenersFirstTime) {
+            addCleanupListener(() => {
+                video.removeEventListener("play", playListener);
+                video.removeEventListener("playing", playingListener);
+                video.removeEventListener("seeking", seekingListener);
+                video.removeEventListener("ratechange", rateChangeListener);
+                video.removeEventListener("videoSpeed_ratechange", rateChangeListener);
+                video.removeEventListener("pause", pauseListener);
+                video.removeEventListener("waiting", waitingListener);
+
+                if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
+            });
         }
     }
 
-    // notify popup of segment changes
-    chrome.runtime.sendMessage({
-        message: "infoUpdated",
-        found: contentState.sponsorDataFound,
-        status: contentState.lastResponseStatus,
-        sponsorTimes: contentState.sponsorTimes,
-        portVideo: contentState.portVideo,
-        time: getVideo()?.currentTime ?? 0,
-    });
-
-    if (Config.config.isVip) {
-        lockedCategoriesLookup();
-    }
-}
-
-async function lockedCategoriesLookup(): Promise<void> {
-    const hashPrefix = (await getHash(getVideoID(), 1)).slice(0, 4);
-    const response = await asyncRequestToServer("GET", "/api/lockCategories/" + hashPrefix);
-
-    if (response.ok) {
-        try {
-            const categoriesResponse = JSON.parse(response.responseText).filter(
-                (lockInfo) => lockInfo.videoID === getVideoID()
-            )[0]?.categories;
-            if (Array.isArray(categoriesResponse)) {
-                contentState.lockedCategories = categoriesResponse;
-            }
-        } catch (e) { } //eslint-disable-line no-empty
-    }
+    setupVideoListenersFirstTime = false;
 }
 
 
@@ -549,553 +539,7 @@ function videoElementChange(newVideo: boolean, video: HTMLVideoElement): void {
     });
 }
 
-
-/** Creates any missing buttons on the player and updates their visiblity. */
-async function updateVisibilityOfPlayerControlsButton(): Promise<void> {
-    // Not on a proper video yet
-    if (!getVideoID()) return;
-
-    contentState.playerButtons = await playerButton.createButtons();
-
-    updateSegmentSubmitting();
-}
-
-/** Updates the visibility of buttons on the player related to creating segments. */
-function updateSegmentSubmitting(): void {
-    // Don't try to update the buttons if we aren't on a Bilibili video page
-    if (!getVideoID()) return;
-    playerButton.updateSegmentSubmitting(contentState.sponsorTimesSubmitting);
-}
-
-/**
- * Used for submitting. This will use the HTML displayed number when required as the video's
- * current time is out of date while scrubbing or at the end of the getVideo(). This is not needed
- * for sponsor skipping as the video is not playing during these times.
- */
-function getRealCurrentTime(): number {
-    // Used to check if ending backdrop is selected
-    const endingDataSelect = document.querySelector(".bpx-player-ending-wrap")?.getAttribute("data-select");
-
-    if (endingDataSelect === "1") {
-        // At the end of the video
-        return getVideo()?.duration;
-    } else {
-        return getVideo().currentTime;
-    }
-}
-
-function startOrEndTimingNewSegment() {
-    const roundedTime = Math.round((getRealCurrentTime() + Number.EPSILON) * 1000) / 1000;
-    if (!isSegmentCreationInProgress()) {
-        contentState.sponsorTimesSubmitting.push({
-            cid: getCid(),
-            segment: [roundedTime],
-            UUID: generateUserID() as SegmentUUID,
-            category: Config.config.defaultCategory,
-            actionType: ActionType.Skip,
-            source: SponsorSourceType.Local,
-        });
-    } else {
-        // Finish creating the new segment
-        const existingSegment = getIncompleteSegment();
-        const existingTime = existingSegment.segment[0];
-        const currentTime = roundedTime;
-
-        // Swap timestamps if the user put the segment end before the start
-        existingSegment.segment = [Math.min(existingTime, currentTime), Math.max(existingTime, currentTime)];
-    }
-
-    // Save the newly created segment
-    Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
-    Config.forceLocalUpdate("unsubmittedSegments");
-
-    // Make sure they know if someone has already submitted something it while they were watching
-    sponsorsLookup(true, true);
-
-    updateSegmentSubmitting();
-    updateSponsorTimesSubmitting(false);
-
-    if (
-        contentState.lastResponseStatus !== 200 &&
-        contentState.lastResponseStatus !== 404 &&
-        !contentState.shownSegmentFailedToFetchWarning &&
-        Config.config.showSegmentFailedToFetchWarning
-    ) {
-        showMessage(chrome.i18n.getMessage("segmentFetchFailureWarning"), "warning");
-
-        contentState.shownSegmentFailedToFetchWarning = true;
-    }
-}
-
-function getIncompleteSegment(): SponsorTime {
-    return contentState.sponsorTimesSubmitting[contentState.sponsorTimesSubmitting.length - 1];
-}
-
-/** Is the latest submitting segment incomplete */
-function isSegmentCreationInProgress(): boolean {
-    const segment = getIncompleteSegment();
-    return segment && segment?.segment?.length !== 2;
-}
-
-function cancelCreatingSegment() {
-    if (isSegmentCreationInProgress()) {
-        if (contentState.sponsorTimesSubmitting.length > 1) {
-            // If there's more than one segment: remove last
-            contentState.sponsorTimesSubmitting.pop();
-            Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
-        } else {
-            // Otherwise delete the video entry & close submission menu
-            resetSponsorSubmissionNotice();
-            contentState.sponsorTimesSubmitting = [];
-            delete Config.local.unsubmittedSegments[getVideoID()];
-        }
-        Config.forceLocalUpdate("unsubmittedSegments");
-    }
-
-    updateSegmentSubmitting();
-    updateSponsorTimesSubmitting(false);
-}
-
-function updateSponsorTimesSubmitting(getFromConfig = true) {
-    const segmentTimes = Config.local.unsubmittedSegments[getVideoID()];
-
-    //see if this data should be saved in the sponsorTimesSubmitting variable
-    if (getFromConfig && segmentTimes != undefined) {
-        contentState.sponsorTimesSubmitting = [];
-
-        for (const segmentTime of segmentTimes) {
-            contentState.sponsorTimesSubmitting.push({
-                cid: getCid(),
-                segment: segmentTime.segment,
-                UUID: segmentTime.UUID,
-                category: segmentTime.category,
-                actionType: segmentTime.actionType,
-                source: segmentTime.source,
-            });
-        }
-
-        if (contentState.sponsorTimesSubmitting.length > 0) {
-            // Assume they already previewed a segment
-            contentState.previewedSegment = true;
-        }
-    }
-
-    updatePreviewBar();
-
-    // Restart skipping schedule
-    if (getVideo() !== null) startSponsorSchedule();
-
-    if (contentState.submissionNotice !== null) {
-        contentState.submissionNotice.update();
-    }
-
-    checkForPreloadedSegment();
-}
-
-function openInfoMenu() {
-    if (document.getElementById("sponsorBlockPopupContainer") != null) {
-        //it's already added
-        return;
-    }
-
-    contentState.popupInitialised = false;
-
-    const popup = document.createElement("div");
-    popup.id = "sponsorBlockPopupContainer";
-
-    const frame = document.createElement("iframe");
-    frame.width = "374";
-    frame.height = "500";
-    frame.style.borderRadius = "6px";
-    frame.style.margin = "0px auto 20px";
-    frame.addEventListener("load", async () => {
-        frame.contentWindow.postMessage("", "*");
-
-        // To support userstyles applying to the popup
-        const stylusStyle = document.querySelector(".stylus");
-        if (stylusStyle) {
-            frame.contentWindow.postMessage(
-                {
-                    type: "style",
-                    css: stylusStyle.textContent,
-                },
-                "*"
-            );
-        }
-    });
-    frame.src = chrome.runtime.getURL("popup.html");
-    popup.appendChild(frame);
-
-    // insert into the avatar container to prevent the popup from being cut off
-    const container = document.querySelector("#danmukuBox") as HTMLElement;
-    container.prepend(popup);
-}
-
-function closeInfoMenu() {
-    const popup = document.getElementById("sponsorBlockPopupContainer");
-    if (popup === null) return;
-
-    popup.remove();
-
-    // show info button again
-    window.dispatchEvent(new Event("closePopupMenu"));
-}
-
-function clearSponsorTimes() {
-    const currentVideoID = getVideoID();
-
-    const sponsorTimes = Config.local.unsubmittedSegments[currentVideoID];
-
-    if (sponsorTimes != undefined && sponsorTimes.length > 0) {
-        resetSponsorSubmissionNotice();
-
-        //clear the sponsor times
-        delete Config.local.unsubmittedSegments[currentVideoID];
-        Config.forceLocalUpdate("unsubmittedSegments");
-
-        //clear sponsor times submitting
-        contentState.sponsorTimesSubmitting = [];
-
-        updatePreviewBar();
-        updateSegmentSubmitting();
-    }
-}
-
-//if skipNotice is null, it will not affect the UI
-async function vote(
-    type: number,
-    UUID: SegmentUUID,
-    category?: Category,
-    skipNotice?: SkipNoticeComponent
-): Promise<VoteResponse> {
-    if (skipNotice !== null && skipNotice !== undefined) {
-        //add loading info
-        skipNotice.addVoteButtonInfo.bind(skipNotice)(chrome.i18n.getMessage("Loading"));
-        skipNotice.setNoticeInfoMessage.bind(skipNotice)();
-    }
-
-    const response = await voteAsync(type, UUID, category);
-    if (response != undefined) {
-        //see if it was a success or failure
-        if (skipNotice != null) {
-            if (response.successType == 1 || (response.successType == -1 && response.statusCode == 429)) {
-                //success (treat rate limits as a success)
-                skipNotice.afterVote.bind(skipNotice)(utils.getSponsorTimeFromUUID(contentState.sponsorTimes, UUID), type, category);
-            } else if (response.successType == -1) {
-                if (
-                    response.statusCode === 403 &&
-                    response.responseText.startsWith("Vote rejected due to a tip from a moderator.")
-                ) {
-                    openWarningDialog(skipNoticeContentContainer);
-                } else {
-                    skipNotice.setNoticeInfoMessage.bind(skipNotice)(
-                        getErrorMessage(response.statusCode, response.responseText)
-                    );
-                }
-
-                skipNotice.resetVoteButtonInfo.bind(skipNotice)();
-            }
-        }
-    }
-
-    return response;
-}
-
-async function voteAsync(type: number, UUID: SegmentUUID, category?: Category): Promise<VoteResponse | undefined> {
-    const sponsorIndex = utils.getSponsorIndexFromUUID(contentState.sponsorTimes, UUID);
-
-    // Don't vote for preview sponsors
-    if (sponsorIndex == -1 || contentState.sponsorTimes[sponsorIndex].source !== SponsorSourceType.Server)
-        return Promise.resolve(undefined);
-
-    // See if the local time saved count and skip count should be saved
-    if ((type === 0 && contentState.sponsorSkipped[sponsorIndex]) || (type === 1 && !contentState.sponsorSkipped[sponsorIndex])) {
-        let factor = 1;
-        if (type == 0) {
-            factor = -1;
-
-            contentState.sponsorSkipped[sponsorIndex] = false;
-        }
-
-        // Count this as a skip
-        Config.config.minutesSaved =
-            Config.config.minutesSaved +
-            (factor * (contentState.sponsorTimes[sponsorIndex].segment[1] - contentState.sponsorTimes[sponsorIndex].segment[0])) / 60;
-
-        Config.config.skipCount = Config.config.skipCount + factor;
-    }
-
-    return new Promise((resolve) => {
-        chrome.runtime.sendMessage(
-            {
-                message: "submitVote",
-                type: type,
-                UUID: UUID,
-                category: category,
-            },
-            (response) => {
-                if (response.successType === 1) {
-                    // Change the sponsor locally
-                    const segment = utils.getSponsorTimeFromUUID(contentState.sponsorTimes, UUID);
-                    if (segment) {
-                        if (type === 0) {
-                            segment.hidden = SponsorHideType.Downvoted;
-                        } else if (category) {
-                            segment.category = category;
-                        } else if (type === 1) {
-                            segment.hidden = SponsorHideType.Visible;
-                        }
-
-                        if (!category && !Config.config.isVip) {
-                            utils.addHiddenSegment(getVideoID(), segment.UUID, segment.hidden);
-                        }
-
-                        updatePreviewBar();
-                    }
-                }
-
-                resolve(response);
-            }
-        );
-    });
-}
-
-//Closes all notices that tell the user that a sponsor was just skipped
-function closeAllSkipNotices() {
-    const notices = document.getElementsByClassName("sponsorSkipNotice");
-    for (let i = 0; i < notices.length; i++) {
-        notices[i].remove();
-    }
-}
-
-function dontShowNoticeAgain() {
-    Config.config.dontShowNotice = true;
-    closeAllSkipNotices();
-}
-
-/**
- * Helper method for the submission notice to clear itself when it closes
- */
-function resetSponsorSubmissionNotice(callRef = true) {
-    contentState.submissionNotice?.close(callRef);
-    contentState.submissionNotice = null;
-}
-
-function closeSubmissionMenu() {
-    contentState.submissionNotice?.close();
-    contentState.submissionNotice = null;
-}
-
-function openSubmissionMenu() {
-    if (contentState.submissionNotice !== null) {
-        closeSubmissionMenu();
-        return;
-    }
-
-    if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0) {
-        contentState.submissionNotice = new SubmissionNotice(skipNoticeContentContainer, sendSubmitMessage);
-        // Add key bind for jumpping to next frame, for easier sponsor time editting
-        document.addEventListener("keydown", seekFrameByKeyPressListener);
-    }
-}
-
-function previewRecentSegment() {
-    if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0) {
-        previewTime(contentState.sponsorTimesSubmitting[contentState.sponsorTimesSubmitting.length - 1].segment[0] - defaultPreviewTime);
-
-        if (contentState.submissionNotice) {
-            contentState.submissionNotice.scrollToBottom();
-        }
-    }
-}
-
-function submitSegments() {
-    if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0 && contentState.submissionNotice !== null) {
-        contentState.submissionNotice.submit();
-    }
-}
-
-//send the message to the background js
-//called after all the checks have been made that it's okay to do so
-async function sendSubmitMessage(): Promise<boolean> {
-    // TODO: add checks for premiere videos
-
-    if (
-        !contentState.previewedSegment &&
-        !contentState.sponsorTimesSubmitting.every(
-            (segment) =>
-                [ActionType.Full, ActionType.Poi].includes(segment.actionType) ||
-                segment.segment[1] >= getVideo()?.duration ||
-                segment.segment[0] === 0
-        )
-    ) {
-        showMessage(
-            `${chrome.i18n.getMessage("previewSegmentRequired")} ${keybindToString(Config.config.previewKeybind)}`,
-            "warning"
-        );
-        return false;
-    }
-
-    // Add loading animation
-    contentState.playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadIconSponsorBlocker.svg");
-    const stopAnimation = AnimationUtils.applyLoadingAnimation(contentState.playerButtons.submit.button, 1, () =>
-        updateSegmentSubmitting()
-    );
-
-    //check if a sponsor exceeds the duration of the video
-    for (let i = 0; i < contentState.sponsorTimesSubmitting.length; i++) {
-        if (contentState.sponsorTimesSubmitting[i].segment[1] > getVideo().duration) {
-            contentState.sponsorTimesSubmitting[i].segment[1] = getVideo().duration;
-        }
-    }
-
-    //update sponsorTimes
-    Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
-    Config.forceLocalUpdate("unsubmittedSegments");
-
-    // Check to see if any of the submissions are below the minimum duration set
-    if (Config.config.minDuration > 0) {
-        for (let i = 0; i < contentState.sponsorTimesSubmitting.length; i++) {
-            const duration = contentState.sponsorTimesSubmitting[i].segment[1] - contentState.sponsorTimesSubmitting[i].segment[0];
-            if (duration > 0 && duration < Config.config.minDuration) {
-                const confirmShort =
-                    chrome.i18n.getMessage("shortCheck") + "\n\n" + getSegmentsMessage(contentState.sponsorTimesSubmitting);
-
-                if (!confirm(confirmShort)) return false;
-            }
-        }
-    }
-
-    const response = await asyncRequestToServer("POST", "/api/skipSegments", {
-        videoID: getBvID(),
-        cid: getCid(),
-        userID: Config.config.userID,
-        segments: contentState.sponsorTimesSubmitting,
-        videoDuration: getVideo()?.duration,
-        userAgent: `${chrome.runtime.id}/v${chrome.runtime.getManifest().version}`,
-    });
-
-    if (response.status === 200) {
-        stopAnimation();
-
-        // Remove segments from storage since they've already been submitted
-        delete Config.local.unsubmittedSegments[getVideoID()];
-        Config.forceLocalUpdate("unsubmittedSegments");
-
-        const newSegments = contentState.sponsorTimesSubmitting;
-        try {
-            const receivedNewSegments = JSON.parse(response.responseText);
-            if (receivedNewSegments?.length === newSegments.length) {
-                for (let i = 0; i < receivedNewSegments.length; i++) {
-                    newSegments[i].UUID = receivedNewSegments[i].UUID;
-                    newSegments[i].source = SponsorSourceType.Server;
-                }
-            }
-        } catch (e) { } // eslint-disable-line no-empty
-
-        // Add submissions to current sponsors list
-        contentState.sponsorTimes = (contentState.sponsorTimes || []).concat(newSegments).sort((a, b) => a.segment[0] - b.segment[0]);
-
-        // Increase contribution count
-        Config.config.sponsorTimesContributed = Config.config.sponsorTimesContributed + contentState.sponsorTimesSubmitting.length;
-
-        // New count just used to see if a warning "Read The Guidelines!!" message needs to be shown
-        // One per time submitting
-        Config.config.submissionCountSinceCategories = Config.config.submissionCountSinceCategories + 1;
-
-        // Empty the submitting times
-        contentState.sponsorTimesSubmitting = [];
-
-        updatePreviewBar();
-
-        const fullVideoSegment = contentState.sponsorTimes.filter((time) => time.actionType === ActionType.Full)[0];
-        if (fullVideoSegment) {
-            waitFor(() => contentState.categoryPill).then(() => {
-                contentState.categoryPill?.setSegment(fullVideoSegment);
-            });
-            // refresh the video labels cache
-            getVideoLabel(getVideoID(), true);
-        }
-
-        return true;
-    } else {
-        // Show that the upload failed
-        contentState.playerButtons.submit.button.style.animation = "unset";
-        contentState.playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadFailedIconSponsorBlocker.svg");
-
-        if (
-            response.status === 403 &&
-            response.responseText.startsWith("Submission rejected due to a tip from a moderator.")
-        ) {
-            openWarningDialog(skipNoticeContentContainer);
-        } else {
-            showMessage(getErrorMessage(response.status, response.responseText), "warning");
-        }
-    }
-
-    return false;
-}
-
-//get the message that visually displays the video times
-function getSegmentsMessage(sponsorTimes: SponsorTime[]): string {
-    let sponsorTimesMessage = "";
-
-    for (let i = 0; i < sponsorTimes.length; i++) {
-        for (let s = 0; s < sponsorTimes[i].segment.length; s++) {
-            let timeMessage = getFormattedTime(sponsorTimes[i].segment[s]);
-            //if this is an end time
-            if (s == 1) {
-                timeMessage = " " + chrome.i18n.getMessage("to") + " " + timeMessage;
-            } else if (i > 0) {
-                //add commas if necessary
-                timeMessage = ", " + timeMessage;
-            }
-
-            sponsorTimesMessage += timeMessage;
-        }
-    }
-
-    return sponsorTimesMessage;
-}
-
 export { seekFrameByKeyPressListener } from "./content/hotkeyHandler";
-
-function checkForPreloadedSegment() {
-    if (contentState.loadedPreloadedSegment) return;
-
-    contentState.loadedPreloadedSegment = true;
-    const hashParams = getHashParams();
-
-    let pushed = false;
-    const segments = hashParams.segments;
-    if (Array.isArray(segments)) {
-        for (const segment of segments) {
-            if (Array.isArray(segment.segment)) {
-                if (
-                    !contentState.sponsorTimesSubmitting.some(
-                        (s) => s.segment[0] === segment.segment[0] && s.segment[1] === s.segment[1]
-                    )
-                ) {
-                    contentState.sponsorTimesSubmitting.push({
-                        cid: getCid(),
-                        segment: segment.segment,
-                        UUID: generateUserID() as SegmentUUID,
-                        category: segment.category ? segment.category : Config.config.defaultCategory,
-                        actionType: segment.actionType ? segment.actionType : ActionType.Skip,
-                        source: SponsorSourceType.Local,
-                    });
-
-                    pushed = true;
-                }
-            }
-        }
-    }
-
-    if (pushed) {
-        Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
-        Config.forceLocalUpdate("unsubmittedSegments");
-    }
-}
 
 // Generate and inject a stylesheet that creates CSS variables with configured category colors
 function setCategoryColorCSSVariables() {

--- a/src/content.ts
+++ b/src/content.ts
@@ -2,7 +2,6 @@ import SkipNoticeComponent from "./components/SkipNoticeComponent";
 import Config from "./config";
 import { keybindToString } from "./config/config";
 import { ContentContainer } from "./ContentContainerTypes";
-import PreviewBar, { PreviewBarSegment } from "./js-components/previewBar";
 import { SkipButtonControlBar } from "./js-components/skipButtonControlBar";
 import {
     contentState,
@@ -13,12 +12,20 @@ import {
     skipBuffer,
 } from "./content/state";
 import { danmakuForSkip, initDanmakuSkip } from "./content/danmakuSkip";
+import {
+    checkPreviewbarState,
+    createPreviewBar,
+    initPreviewBarManager,
+    removeDurationAfterSkip,
+    selectSegment,
+    updateActiveSegment,
+    updatePreviewBar,
+} from "./content/previewBarManager";
 import { initMessageHandler, setupMessageListener } from "./content/messageHandler";
 import { addHotkeyListener, initHotkeyHandler, seekFrameByKeyPressListener } from "./content/hotkeyHandler";
 import { VoteResponse } from "./messageTypes";
 import advanceSkipNotice from "./render/advanceSkipNotice";
 import { CategoryPill } from "./render/CategoryPill";
-import { ChapterVote } from "./render/ChapterVote";
 import { DescriptionPortPill } from "./render/DescriptionPortPill";
 import { CommentListener, DynamicListener } from "./render/DynamicAndCommentSponsorBlock";
 import { setMessageNotice, showMessage } from "./render/MessageNotice";
@@ -55,7 +62,6 @@ import { AnimationUtils } from "./utils/animationUtils";
 import { addCleanupListener, cleanPage } from "./utils/cleanup";
 import { defaultPreviewTime } from "./utils/constants";
 import { parseTargetTimeFromDanmaku } from "./utils/danmakusUtils";
-import { findValidElement } from "./utils/dom";
 import { durationEquals } from "./utils/duraionUtils";
 import { getErrorMessage, getFormattedTime } from "./utils/formating";
 import { GenericUtils } from "./utils/genericUtils";
@@ -119,6 +125,8 @@ initDanmakuSkip({
 });
 
 initHotkeyHandler({ startOrEndTimingNewSegment, submitSegments, openSubmissionMenu, previewRecentSegment });
+
+initPreviewBarManager({ voteAsync, updateVisibilityOfPlayerControlsButton });
 
 setupVideoModule({ videoIDChange, channelIDChange, resetValues, videoElementChange });
 
@@ -265,36 +273,6 @@ async function videoIDChange(): Promise<void> {
     if ([PageType.Video, PageType.List, PageType.Dynamic, PageType.Channel, PageType.Opus, PageType.Festival].includes(getPageType()) &&
         (Config.config.dynamicAndCommentSponsorBlocker && Config.config.commentSponsorBlock)
     ) CommentListener();
-}
-
-/**
- * Creates a preview bar on the video
- */
-function createPreviewBar(): void {
-    if (contentState.previewBar !== null) return;
-
-    const progressElementOptions = [
-        {
-            // For Desktop Bilibili
-            selector: ".bpx-player-progress",
-            shadowSelector: ".bpx-player-shadow-progress-area",
-            isVisibleCheck: true,
-        },
-    ];
-
-    for (const option of progressElementOptions) {
-        const allElements = document.querySelectorAll(option.selector) as NodeListOf<HTMLElement>;
-        const parent = option.isVisibleCheck ? findValidElement(allElements) : allElements[0];
-        const allshadowSelectorElements = document.querySelectorAll(option.shadowSelector) as NodeListOf<HTMLElement>;
-        const shadowParent = allshadowSelectorElements[0];
-
-        if (parent) {
-            const chapterVote = new ChapterVote(voteAsync);
-            contentState.previewBar = new PreviewBar(parent, shadowParent, chapterVote);
-            updatePreviewBar();
-            break;
-        }
-    }
 }
 
 /**
@@ -1208,69 +1186,6 @@ function startSkipScheduleCheckingForStartSponsors() {
     }
 }
 
-function selectSegment(UUID: SegmentUUID): void {
-    contentState.selectedSegment = UUID;
-    updatePreviewBar();
-}
-
-function updatePreviewBar(): void {
-    if (contentState.previewBar === null) return;
-    if (getVideo() === null) return;
-
-    const hashParams = getHashParams();
-    const requiredSegment = (hashParams?.requiredSegment as SegmentUUID) || undefined;
-    const previewBarSegments: PreviewBarSegment[] = [];
-    if (contentState.sponsorTimes) {
-        contentState.sponsorTimes.forEach((segment) => {
-            if (segment.hidden !== SponsorHideType.Visible) return;
-
-            previewBarSegments.push({
-                segment: segment.segment as [number, number],
-                category: segment.category,
-                actionType: segment.actionType,
-                unsubmitted: false,
-                showLarger: segment.actionType === ActionType.Poi,
-                source: segment.source,
-                requiredSegment:
-                    requiredSegment && (segment.UUID === requiredSegment || segment.UUID?.startsWith(requiredSegment)),
-                selectedSegment: contentState.selectedSegment && segment.UUID === contentState.selectedSegment,
-            });
-        });
-    }
-
-    contentState.sponsorTimesSubmitting.forEach((segment) => {
-        previewBarSegments.push({
-            segment: segment.segment as [number, number],
-            category: segment.category,
-            actionType: segment.actionType,
-            unsubmitted: true,
-            showLarger: segment.actionType === ActionType.Poi,
-            source: segment.source,
-        });
-    });
-
-    contentState.previewBar.set(
-        previewBarSegments.filter((segment) => segment.actionType !== ActionType.Full),
-        getVideo()?.duration
-    );
-    if (getVideo()) updateActiveSegment(getVideo().currentTime);
-
-    // retry create buttons in case the video is not ready
-    updateVisibilityOfPlayerControlsButton();
-
-    removeDurationAfterSkip();
-    if (Config.config.showTimeWithSkips) {
-        const skippedDuration = utils.getTimestampsDuration(
-            previewBarSegments.filter(({ actionType }) => actionType !== ActionType.Mute).map(({ segment }) => segment)
-        );
-
-        showTimeWithoutSkips(skippedDuration);
-    }
-
-    // Update last video id
-    contentState.lastPreviewBarUpdate = getVideoID();
-}
-
 //checks if this channel is whitelisted, should be done only after the channelID has been loaded
 async function channelIDChange(channelIDInfo: ChannelIDInfo) {
     const whitelistedChannels = Config.config.whitelistedChannels;
@@ -1307,16 +1222,6 @@ function videoElementChange(newVideo: boolean, video: HTMLVideoElement): void {
     });
 }
 
-function checkPreviewbarState(): void {
-    if (contentState.previewBar && !utils.findReferenceNode()?.contains(contentState.previewBar.container)) {
-        contentState.previewBar.remove();
-        contentState.previewBar = null;
-        removeDurationAfterSkip();
-    }
-
-    // wait until the page is active to create the preview bar
-    waitFor(() => !document.hidden, 24 * 60 * 60, 500).then(createPreviewBar);
-}
 
 /**
  * Returns info about the next upcoming sponsor skip
@@ -2315,58 +2220,7 @@ function getSegmentsMessage(sponsorTimes: SponsorTime[]): string {
     return sponsorTimesMessage;
 }
 
-function updateActiveSegment(currentTime: number): void {
-    contentState.previewBar?.updateChapterText(contentState.sponsorTimes, contentState.sponsorTimesSubmitting, currentTime);
-
-    chrome.runtime.sendMessage({
-        message: "time",
-        time: currentTime,
-    });
-}
-
 export { seekFrameByKeyPressListener } from "./content/hotkeyHandler";
-
-const durationID = "sponsorBlockDurationAfterSkips";
-function showTimeWithoutSkips(skippedDuration: number): void {
-    if (isNaN(skippedDuration) || skippedDuration < 0) {
-        skippedDuration = 0;
-    }
-
-    // Video player time display
-    const display = document.querySelector(".bpx-player-ctrl-time-label") as HTMLDivElement;
-    if (!display) return;
-
-    let duration = document.getElementById(durationID);
-
-    // Create span if needed
-    if (duration === null) {
-        duration = document.createElement("span");
-        duration.id = durationID;
-        display.appendChild(duration);
-    }
-
-    const durationAfterSkips = getFormattedTime(getVideo()?.duration - skippedDuration);
-
-    const refreshDurationTextWidth = () => {
-        // some hacks to change the min-width of the time control area,
-        // so it won't overlap with chapters on the right
-        display.style.width = "auto";
-        display.parentElement.style.minWidth = `${display.clientWidth - 11}px`;
-    };
-
-    if (durationAfterSkips != null && skippedDuration > 0) {
-        duration.innerText = " (" + durationAfterSkips + ")";
-
-        refreshDurationTextWidth();
-        // re-calculate text position after entering and exiting full screen
-        window.addEventListener("fullscreenchange", refreshDurationTextWidth);
-    }
-}
-
-function removeDurationAfterSkip() {
-    const duration = document.getElementById(durationID);
-    duration?.remove();
-}
 
 function checkForPreloadedSegment() {
     if (contentState.loadedPreloadedSegment) return;

--- a/src/content.ts
+++ b/src/content.ts
@@ -5,11 +5,8 @@ import { ContentContainer } from "./ContentContainerTypes";
 import { SkipButtonControlBar } from "./js-components/skipButtonControlBar";
 import {
     contentState,
-    endTimeSkipBuffer,
     getPageLoaded,
-    manualSkipPercentCount,
     setupPageLoadingListener,
-    skipBuffer,
 } from "./content/state";
 import { danmakuForSkip, initDanmakuSkip } from "./content/danmakuSkip";
 import {
@@ -21,16 +18,29 @@ import {
     updateActiveSegment,
     updatePreviewBar,
 } from "./content/previewBarManager";
+import {
+    cancelSponsorSchedule,
+    clearWaitingTime,
+    getVirtualTime,
+    initSkipScheduler,
+    isSegmentMarkedNearCurrentTime,
+    previewTime,
+    reskipSponsorTime,
+    skipToTime,
+    startSkipScheduleCheckingForStartSponsors,
+    startSponsorSchedule,
+    unskipSponsorTime,
+    updateVirtualTime,
+    updateWaitingTime,
+} from "./content/skipScheduler";
 import { initMessageHandler, setupMessageListener } from "./content/messageHandler";
 import { addHotkeyListener, initHotkeyHandler, seekFrameByKeyPressListener } from "./content/hotkeyHandler";
 import { VoteResponse } from "./messageTypes";
-import advanceSkipNotice from "./render/advanceSkipNotice";
 import { CategoryPill } from "./render/CategoryPill";
 import { DescriptionPortPill } from "./render/DescriptionPortPill";
 import { CommentListener, DynamicListener } from "./render/DynamicAndCommentSponsorBlock";
 import { setMessageNotice, showMessage } from "./render/MessageNotice";
 import { PlayerButton } from "./render/PlayerButton";
-import SkipNotice from "./render/SkipNotice";
 import SubmissionNotice from "./render/SubmissionNotice";
 import { getPortVideoByHash, postPortVideo, postPortVideoVote, updatePortedSegments } from "./requests/portVideo";
 import { asyncRequestToServer } from "./requests/requests";
@@ -42,39 +52,31 @@ import {
     ActionType,
     BVID,
     Category,
-    CategorySkipOption,
     ChannelIDInfo,
     ChannelIDStatus,
     NewVideoID,
     PageType,
     PortVideo,
-    ScheduledTime,
     SegmentUUID,
-    SkipToTimeParams,
     SponsorHideType,
     SponsorSourceType,
     SponsorTime,
     YTID,
 } from "./types";
 import Utils from "./utils";
-import { isFirefox, isFirefoxOrSafari, isSafari, waitFor } from "./utils/";
+import { waitFor } from "./utils/";
 import { AnimationUtils } from "./utils/animationUtils";
 import { addCleanupListener, cleanPage } from "./utils/cleanup";
 import { defaultPreviewTime } from "./utils/constants";
-import { parseTargetTimeFromDanmaku } from "./utils/danmakusUtils";
 import { durationEquals } from "./utils/duraionUtils";
 import { getErrorMessage, getFormattedTime } from "./utils/formating";
 import { GenericUtils } from "./utils/genericUtils";
 import { getHash, getVideoIDHash, HashedValue } from "./utils/hash";
 import { getCidMapFromWindow } from "./utils/injectedScriptMessageUtils";
 import { logDebug } from "./utils/logger";
-import { getControls, getHashParams, getProgressBar, isPlayingPlaylist } from "./utils/pageUtils";
-import { getBilibiliVideoID } from "./utils/parseVideoID";
+import { getControls, getHashParams, getProgressBar } from "./utils/pageUtils";
 import { generateUserID } from "./utils/setup";
-import { getStartTimeFromUrl } from "./utils/urlParser";
 import {
-    checkIfNewVideoID,
-    checkVideoIDChange,
     detectPageType,
     getBvID,
     getChannelIDInfo,
@@ -169,6 +171,11 @@ const skipNoticeContentContainer: ContentContainer = () => ({
     getRealCurrentTime: getRealCurrentTime,
     lockedCategories: contentState.lockedCategories,
     channelIDInfo: getChannelIDInfo(),
+});
+
+initSkipScheduler({
+    skipNoticeContentContainer,
+    updateActiveSegment,
 });
 
 initMessageHandler({
@@ -293,345 +300,6 @@ function videoOnReadyListener(): void {
     updateVisibilityOfPlayerControlsButton();
 }
 
-function cancelSponsorSchedule(): void {
-    logDebug("Pausing skipping");
-
-    if (contentState.currentSkipSchedule !== null) {
-        clearTimeout(contentState.currentSkipSchedule);
-        contentState.currentSkipSchedule = null;
-    }
-
-    if (contentState.currentSkipInterval !== null) {
-        clearInterval(contentState.currentSkipInterval);
-        contentState.currentSkipInterval = null;
-    }
-
-    if (contentState.currentadvanceSkipSchedule !== null) {
-        clearInterval(contentState.currentadvanceSkipSchedule);
-        contentState.currentadvanceSkipSchedule = null;
-    }
-}
-
-/**
- * @param currentTime Optional if you don't want to use the actual current time
- */
-async function startSponsorSchedule(
-    includeIntersectingSegments = false,
-    currentTime?: number,
-    includeNonIntersectingSegments = true
-): Promise<void> {
-    cancelSponsorSchedule();
-
-    // Give up if video changed, and trigger a videoID change if so
-    if (await checkIfNewVideoID()) {
-        return;
-    }
-
-    const video = getVideo();
-    logDebug(`Considering to start skipping: ${!video}, ${video?.paused}`);
-    if (!video) return;
-    if (currentTime === undefined || currentTime === null) {
-        currentTime = getVirtualTime();
-    }
-    clearWaitingTime();
-
-    updateActiveSegment(currentTime);
-
-    if (video.paused || (video.currentTime >= video.duration - 0.01 && video.duration > 1)) return;
-    const skipInfo = getNextSkipIndex(currentTime, includeIntersectingSegments, includeNonIntersectingSegments);
-
-    const currentSkip = skipInfo.array[skipInfo.index];
-    const skipTime: number[] = [currentSkip?.scheduledTime, skipInfo.array[skipInfo.endIndex]?.segment[1]];
-    const timeUntilSponsor = skipTime?.[0] - currentTime;
-    const videoID = getVideoID();
-
-    if (
-        contentState.videoMuted &&
-        !inMuteSegment(
-            currentTime,
-            skipInfo.index !== -1 && timeUntilSponsor < skipBuffer && shouldAutoSkip(currentSkip)
-        )
-    ) {
-        video.muted = false;
-        contentState.videoMuted = false;
-
-        for (const notice of contentState.skipNotices) {
-            // So that the notice can hide buttons
-            notice.unmutedListener(currentTime);
-        }
-    }
-
-    logDebug(`Ready to start skipping: ${skipInfo.index} at ${currentTime}`);
-    if (skipInfo.index === -1) return;
-
-    if (
-        Config.config.disableSkipping ||
-        contentState.channelWhitelisted ||
-        (getChannelIDInfo().status === ChannelIDStatus.Fetching && Config.config.forceChannelCheck)
-    ) {
-        return;
-    }
-
-    if (await incorrectVideoCheck()) return;
-
-    // Find all indexes in between the start and end
-    let skippingSegments = [skipInfo.array[skipInfo.index]];
-    if (skipInfo.index !== skipInfo.endIndex) {
-        skippingSegments = [];
-
-        for (const segment of skipInfo.array) {
-            if (
-                shouldAutoSkip(segment) &&
-                segment.segment[0] >= skipTime[0] &&
-                segment.segment[1] <= skipTime[1] &&
-                segment.segment[0] === segment.scheduledTime
-            ) {
-                // Don't include artifical scheduled segments (end times for mutes)
-                skippingSegments.push(segment);
-            }
-        }
-    }
-
-    logDebug(
-        `Next step in starting skipping: ${!shouldSkip(currentSkip)}, ${!contentState.sponsorTimesSubmitting?.some(
-            (segment) => segment.segment === currentSkip.segment
-        )}`
-    );
-
-    const skippingFunction = async (forceVideoTime?: number) => {
-        let forcedSkipTime: number = null;
-        let forcedIncludeIntersectingSegments = false;
-        let forcedIncludeNonIntersectingSegments = true;
-
-        if (await incorrectVideoCheck(videoID, currentSkip)) return;
-        forceVideoTime ||= Math.max(getVideo().currentTime, getVirtualTime());
-
-        if (
-            shouldSkip(currentSkip) ||
-            contentState.sponsorTimesSubmitting?.some((segment) => segment.segment === currentSkip.segment)
-        ) {
-            if (forceVideoTime >= skipTime[0] - skipBuffer && forceVideoTime < skipTime[1]) {
-                skipToTime({
-                    v: getVideo(),
-                    skipTime,
-                    skippingSegments,
-                    openNotice: skipInfo.openNotice,
-                });
-
-                // These are segments that start at the exact same time but need seperate notices
-                for (const extra of skipInfo.extraIndexes) {
-                    const extraSkip = skipInfo.array[extra];
-                    if (shouldSkip(extraSkip)) {
-                        skipToTime({
-                            v: getVideo(),
-                            skipTime: [extraSkip.scheduledTime, extraSkip.segment[1]],
-                            skippingSegments: [extraSkip],
-                            openNotice: skipInfo.openNotice,
-                        });
-                    }
-                }
-
-                if (
-                    utils.getCategorySelection(currentSkip.category)?.option === CategorySkipOption.ManualSkip ||
-                    currentSkip.actionType === ActionType.Mute
-                ) {
-                    forcedSkipTime = skipTime[0] + 0.001;
-                } else {
-                    forcedSkipTime = skipTime[1];
-                    forcedIncludeNonIntersectingSegments = false;
-
-                    // Only if not at the end of the video
-                    if (Math.abs(skipTime[1] - getVideo().duration) > endTimeSkipBuffer) {
-                        forcedIncludeIntersectingSegments = true;
-                    }
-                }
-            } else {
-                forcedSkipTime = forceVideoTime + 0.001;
-            }
-        } else {
-            forcedSkipTime = forceVideoTime + 0.001;
-        }
-
-        // Don't pretend to be earlier than we are, could result in loops
-        if (forcedSkipTime !== null && forceVideoTime > forcedSkipTime) {
-            forcedSkipTime = forceVideoTime;
-        }
-
-        startSponsorSchedule(forcedIncludeIntersectingSegments, forcedSkipTime, forcedIncludeNonIntersectingSegments);
-    };
-
-    if (timeUntilSponsor < skipBuffer) {
-        await skippingFunction(currentTime);
-    } else {
-        let delayTime = (timeUntilSponsor * 1000) / getVideo().playbackRate;
-        if (delayTime < (isFirefox() ? 750 : 300) && shouldAutoSkip(skippingSegments[0])) {
-            let forceStartIntervalTime: number | null = null;
-            if (isFirefox() && delayTime > 300) {
-                forceStartIntervalTime = await waitForNextTimeChange();
-            }
-
-            // Use interval instead of timeout near the end to combat imprecise video time
-            const startIntervalTime = forceStartIntervalTime || performance.now();
-            const startVideoTime = Math.max(currentTime, getVideo().currentTime);
-            delayTime = (skipTime?.[0] - startVideoTime) * 1000 * (1 / getVideo().playbackRate);
-
-            let startWaitingForReportedTimeToChange = true;
-            const reportedVideoTimeAtStart = getVideo().currentTime;
-            logDebug(`Starting setInterval skipping ${getVideo().currentTime} to skip at ${skipTime[0]}`);
-
-            if (contentState.currentSkipInterval !== null) clearInterval(contentState.currentSkipInterval);
-            contentState.currentSkipInterval = setInterval(() => {
-                // Estimate delay, but only take the current time right after a change
-                // Current time remains the same for many "frames" on Firefox
-                if (
-                    isFirefoxOrSafari() &&
-                    !contentState.lastKnownVideoTime.fromPause &&
-                    startWaitingForReportedTimeToChange &&
-                    reportedVideoTimeAtStart !== getVideo().currentTime
-                ) {
-                    startWaitingForReportedTimeToChange = false;
-                    const delay = getVirtualTime() - getVideo().currentTime;
-                    if (delay > 0) contentState.lastKnownVideoTime.approximateDelay = delay;
-                }
-
-                const intervalDuration = performance.now() - startIntervalTime;
-                if (intervalDuration + skipBuffer * 1000 >= delayTime || getVideo().currentTime >= skipTime[0]) {
-                    clearInterval(contentState.currentSkipInterval);
-                    if (!isFirefoxOrSafari() && !getVideo().muted && !inMuteSegment(getVideo().currentTime, true)) {
-                        // Workaround for more accurate skipping on Chromium
-                        getVideo().muted = true;
-                        getVideo().muted = false;
-                    }
-
-                    skippingFunction(
-                        Math.max(
-                            getVideo().currentTime,
-                            startVideoTime + (getVideo().playbackRate * Math.max(delayTime, intervalDuration)) / 1000
-                        )
-                    );
-                }
-            }, 0);
-        } else {
-            logDebug(`Starting timeout to skip ${getVideo().currentTime} to skip at ${skipTime[0]}`);
-
-            const offset = isFirefoxOrSafari() && !isSafari() ? 600 : 150;
-            // Schedule for right before to be more precise than normal timeout
-            const offsetDelayTime = Math.max(0, delayTime - offset);
-            contentState.currentSkipSchedule = setTimeout(skippingFunction, offsetDelayTime);
-
-            if (
-                Config.config.advanceSkipNotice &&
-                Config.config.skipNoticeDurationBefore > 0 &&
-                getVideo().currentTime < skippingSegments[0].segment[0] &&
-                !contentState.sponsorTimesSubmitting?.some((segment) => segment.segment === currentSkip.segment) &&
-                [ActionType.Skip, ActionType.Mute].includes(skippingSegments[0].actionType) &&
-                shouldAutoSkip(skippingSegments[0]) &&
-                !getVideo()?.paused
-            ) {
-                const maxPopupTime = Config.config.skipNoticeDurationBefore * 1000;
-                const timeUntilPopup = Math.max(0, offsetDelayTime - maxPopupTime);
-                const autoSkip = shouldAutoSkip(skippingSegments[0]);
-
-                if (contentState.currentadvanceSkipSchedule) clearTimeout(contentState.currentadvanceSkipSchedule);
-                contentState.currentadvanceSkipSchedule = setTimeout(() => {
-                    createAdvanceSkipNotice([skippingSegments[0]], skipTime[0], autoSkip, false);
-                    sessionStorage.setItem("SKIPPING", "true");
-                }, timeUntilPopup);
-            }
-        }
-    }
-}
-
-
-/**
- * Used on Firefox only, waits for the next animation frame until
- * the video time has changed
- */
-function waitForNextTimeChange(): Promise<DOMHighResTimeStamp | null> {
-    return new Promise((resolve) => {
-        getVideo().addEventListener("timeupdate", () => resolve(performance.now()), { once: true });
-    });
-}
-
-function getVirtualTime(): number {
-    const virtualTime =
-        contentState.lastTimeFromWaitingEvent ??
-        (contentState.lastKnownVideoTime.videoTime !== null
-            ? ((performance.now() - contentState.lastKnownVideoTime.preciseTime) * getVideo().playbackRate) / 1000 +
-            contentState.lastKnownVideoTime.videoTime
-            : null);
-
-    if (
-        Config.config.useVirtualTime &&
-        !isSafari() &&
-        virtualTime &&
-        Math.abs(virtualTime - getVideo().currentTime) < 0.2 &&
-        getVideo().currentTime !== 0
-    ) {
-        return Math.max(virtualTime, getVideo().currentTime);
-    } else {
-        return getVideo().currentTime;
-    }
-}
-
-function inMuteSegment(currentTime: number, includeOverlap: boolean): boolean {
-    const checkFunction = (segment) =>
-        segment.actionType === ActionType.Mute &&
-        segment.hidden === SponsorHideType.Visible &&
-        segment.segment[0] <= currentTime &&
-        (segment.segment[1] > currentTime || (includeOverlap && segment.segment[1] + 0.02 > currentTime));
-    return contentState.sponsorTimes?.some(checkFunction) || contentState.sponsorTimesSubmitting.some(checkFunction);
-}
-
-function isSegmentMarkedNearCurrentTime(currentTime: number, range: number = 5): boolean {
-    const lowerBound = currentTime - range;
-    const upperBound = currentTime + range;
-
-    return contentState.sponsorTimes?.some((sponsorTime) => {
-        const {
-            segment: [startTime, endTime],
-        } = sponsorTime;
-        return startTime <= upperBound && endTime >= lowerBound;
-    });
-}
-
-/**
- * This makes sure the videoID is still correct and if the sponsorTime is included
- */
-async function incorrectVideoCheck(videoID?: string, sponsorTime?: SponsorTime): Promise<boolean> {
-    const currentVideoID = await getBilibiliVideoID();
-    const recordedVideoID = videoID || getVideoID();
-    if (
-        currentVideoID !== recordedVideoID ||
-        (sponsorTime &&
-            (!contentState.sponsorTimes ||
-                !contentState.sponsorTimes?.some(
-                    (time) => time.segment[0] === sponsorTime.segment[0] && time.segment[1] === sponsorTime.segment[1]
-                )) &&
-            !contentState.sponsorTimesSubmitting.some(
-                (time) => time.segment[0] === sponsorTime.segment[0] && time.segment[1] === sponsorTime.segment[1]
-            ))
-    ) {
-        // Something has really gone wrong
-        console.error("[SponsorBlock] The videoID recorded when trying to skip is different than what it should be.");
-        console.error("[SponsorBlock] VideoID recorded: " + recordedVideoID + ". Actual VideoID: " + currentVideoID);
-        console.error(
-            "[SponsorBlock] SponsorTime",
-            sponsorTime,
-            "sponsorTimes",
-            contentState.sponsorTimes,
-            "sponsorTimesSubmitting",
-            contentState.sponsorTimesSubmitting
-        );
-
-        // Video ID change occured
-        checkVideoIDChange();
-
-        return true;
-    } else {
-        return false;
-    }
-}
 
 let playbackRateCheckInterval: NodeJS.Timeout | null = null;
 let lastPlaybackSpeed = 1;
@@ -829,56 +497,6 @@ function setupVideoListeners(video: HTMLVideoElement) {
     setupVideoListenersFirstTime = false;
 }
 
-function updateVirtualTime() {
-    if (contentState.currentVirtualTimeInterval) clearInterval(contentState.currentVirtualTimeInterval);
-
-    contentState.lastKnownVideoTime.videoTime = getVideo().currentTime;
-    contentState.lastKnownVideoTime.preciseTime = performance.now();
-
-    // If on Firefox, wait for the second time change (time remains fixed for many "frames" for privacy reasons)
-    if (isFirefoxOrSafari()) {
-        let count = 0;
-        let rawCount = 0;
-        let lastTime = contentState.lastKnownVideoTime.videoTime;
-        let lastPerformanceTime = performance.now();
-
-        contentState.currentVirtualTimeInterval = setInterval(() => {
-            const frameTime = performance.now() - lastPerformanceTime;
-            if (lastTime !== getVideo().currentTime) {
-                rawCount++;
-
-                // If there is lag, give it another shot at finding a good change time
-                if (frameTime < 20 || rawCount > 30) {
-                    count++;
-                }
-                lastTime = getVideo().currentTime;
-            }
-
-            if (count > 1) {
-                const delay =
-                    contentState.lastKnownVideoTime.fromPause && contentState.lastKnownVideoTime.approximateDelay
-                        ? contentState.lastKnownVideoTime.approximateDelay
-                        : 0;
-
-                contentState.lastKnownVideoTime.videoTime = getVideo().currentTime + delay;
-                contentState.lastKnownVideoTime.preciseTime = performance.now();
-
-                clearInterval(contentState.currentVirtualTimeInterval);
-                contentState.currentVirtualTimeInterval = null;
-            }
-
-            lastPerformanceTime = performance.now();
-        }, 1);
-    }
-}
-
-function updateWaitingTime(): void {
-    contentState.lastTimeFromWaitingEvent = getVideo().currentTime;
-}
-
-function clearWaitingTime(): void {
-    contentState.lastTimeFromWaitingEvent = null;
-}
 
 function setupSkipButtonControlBar() {
     if (!contentState.skipButtonControlBar) {
@@ -1110,82 +728,6 @@ async function lockedCategoriesLookup(): Promise<void> {
 }
 
 
-/**
- * Only should be used when it is okay to skip a sponsor when in the middle of it
- *
- * Ex. When segments are first loaded
- */
-function startSkipScheduleCheckingForStartSponsors() {
-    // switchingVideos is ignored in Safari due to event fire order. See #1142
-    if ((!contentState.switchingVideos || isSafari()) && contentState.sponsorTimes) {
-        // See if there are any starting sponsors
-        let startingSegmentTime = getStartTimeFromUrl(document.URL) || -1;
-        let found = false;
-        for (const time of contentState.sponsorTimes) {
-            if (
-                time.segment[0] <= getVideo().currentTime &&
-                time.segment[0] > startingSegmentTime &&
-                time.segment[1] > getVideo().currentTime &&
-                time.actionType !== ActionType.Poi
-            ) {
-                startingSegmentTime = time.segment[0];
-                found = true;
-                break;
-            }
-        }
-        if (!found) {
-            for (const time of contentState.sponsorTimesSubmitting) {
-                if (
-                    time.segment[0] <= getVideo().currentTime &&
-                    time.segment[0] > startingSegmentTime &&
-                    time.segment[1] > getVideo().currentTime &&
-                    time.actionType !== ActionType.Poi
-                ) {
-                    startingSegmentTime = time.segment[0];
-                    found = true;
-                    break;
-                }
-            }
-        }
-
-        // For highlight category
-        const poiSegments = contentState.sponsorTimes
-            .filter(
-                (time) =>
-                    time.segment[1] > getVideo().currentTime &&
-                    time.actionType === ActionType.Poi &&
-                    time.hidden === SponsorHideType.Visible
-            )
-            .sort((a, b) => b.segment[0] - a.segment[0]);
-        for (const time of poiSegments) {
-            const skipOption = utils.getCategorySelection(time.category)?.option;
-            if (skipOption !== CategorySkipOption.ShowOverlay) {
-                skipToTime({
-                    v: getVideo(),
-                    skipTime: time.segment,
-                    skippingSegments: [time],
-                    openNotice: true,
-                    unskipTime: getVideo().currentTime,
-                });
-                if (skipOption === CategorySkipOption.AutoSkip) break;
-            }
-        }
-
-        const fullVideoSegment = contentState.sponsorTimes.filter((time) => time.actionType === ActionType.Full)[0];
-        if (fullVideoSegment) {
-            waitFor(() => contentState.categoryPill).then(() => {
-                contentState.categoryPill?.setSegment(fullVideoSegment);
-            });
-        }
-
-        if (startingSegmentTime !== -1) {
-            startSponsorSchedule(undefined, startingSegmentTime);
-        } else {
-            startSponsorSchedule();
-        }
-    }
-}
-
 //checks if this channel is whitelisted, should be done only after the channelID has been loaded
 async function channelIDChange(channelIDInfo: ChannelIDInfo) {
     const whitelistedChannels = Config.config.whitelistedChannels;
@@ -1222,495 +764,6 @@ function videoElementChange(newVideo: boolean, video: HTMLVideoElement): void {
     });
 }
 
-
-/**
- * Returns info about the next upcoming sponsor skip
- */
-function getNextSkipIndex(
-    currentTime: number,
-    includeIntersectingSegments: boolean,
-    includeNonIntersectingSegments: boolean
-): { array: ScheduledTime[]; index: number; endIndex: number; extraIndexes: number[]; openNotice: boolean } {
-    const autoSkipSorter = (segment: ScheduledTime) => {
-        const skipOption = utils.getCategorySelection(segment.category)?.option;
-        if (
-            (skipOption === CategorySkipOption.AutoSkip || shouldAutoSkip(segment)) &&
-            segment.actionType === ActionType.Skip
-        ) {
-            return 0;
-        } else if (skipOption !== CategorySkipOption.ShowOverlay) {
-            return 1;
-        } else {
-            return 2;
-        }
-    };
-
-    const { includedTimes: submittedArray, scheduledTimes: sponsorStartTimes } = getStartTimes(
-        contentState.sponsorTimes,
-        includeIntersectingSegments,
-        includeNonIntersectingSegments
-    );
-    const { scheduledTimes: sponsorStartTimesAfterCurrentTime } = getStartTimes(
-        contentState.sponsorTimes,
-        includeIntersectingSegments,
-        includeNonIntersectingSegments,
-        currentTime,
-        true
-    );
-
-    // This is an array in-case multiple segments have the exact same start time
-    const minSponsorTimeIndexes = GenericUtils.indexesOf(
-        sponsorStartTimes,
-        Math.min(...sponsorStartTimesAfterCurrentTime)
-    );
-    // Find auto skipping segments if possible, sort by duration otherwise
-    const minSponsorTimeIndex =
-        minSponsorTimeIndexes.sort(
-            (a, b) =>
-                autoSkipSorter(submittedArray[a]) - autoSkipSorter(submittedArray[b]) ||
-                submittedArray[a].segment[1] -
-                submittedArray[a].segment[0] -
-                (submittedArray[b].segment[1] - submittedArray[b].segment[0])
-        )[0] ?? -1;
-    // Store extra indexes for the non-auto skipping segments if others occur at the exact same start time
-    const extraIndexes = minSponsorTimeIndexes.filter(
-        (i) => i !== minSponsorTimeIndex && autoSkipSorter(submittedArray[i]) !== 0
-    );
-
-    const endTimeIndex = getLatestEndTimeIndex(submittedArray, minSponsorTimeIndex);
-
-    const { includedTimes: unsubmittedArray, scheduledTimes: unsubmittedSponsorStartTimes } = getStartTimes(
-        contentState.sponsorTimesSubmitting,
-        includeIntersectingSegments,
-        includeNonIntersectingSegments
-    );
-    const { scheduledTimes: unsubmittedSponsorStartTimesAfterCurrentTime } = getStartTimes(
-        contentState.sponsorTimesSubmitting,
-        includeIntersectingSegments,
-        includeNonIntersectingSegments,
-        currentTime,
-        false
-    );
-
-    const minUnsubmittedSponsorTimeIndex = unsubmittedSponsorStartTimes.indexOf(
-        Math.min(...unsubmittedSponsorStartTimesAfterCurrentTime)
-    );
-    const previewEndTimeIndex = getLatestEndTimeIndex(unsubmittedArray, minUnsubmittedSponsorTimeIndex);
-
-    if (
-        (minUnsubmittedSponsorTimeIndex === -1 && minSponsorTimeIndex !== -1) ||
-        sponsorStartTimes[minSponsorTimeIndex] < unsubmittedSponsorStartTimes[minUnsubmittedSponsorTimeIndex]
-    ) {
-        return {
-            array: submittedArray,
-            index: minSponsorTimeIndex,
-            endIndex: endTimeIndex,
-            extraIndexes, // Segments at same time that need seperate notices
-            openNotice: true,
-        };
-    } else {
-        return {
-            array: unsubmittedArray,
-            index: minUnsubmittedSponsorTimeIndex,
-            endIndex: previewEndTimeIndex,
-            extraIndexes: [], // No manual things for unsubmitted
-            openNotice: false,
-        };
-    }
-}
-
-/**
- * This returns index if the skip option is not AutoSkip
- *
- * Finds the last endTime that occurs in a segment that the given
- * segment skips into that is part of an AutoSkip category.
- *
- * Used to find where a segment should truely skip to if there are intersecting submissions due to
- * them having different categories.
- *
- * @param sponsorTimes
- * @param index Index of the given sponsor
- * @param hideHiddenSponsors
- */
-function getLatestEndTimeIndex(sponsorTimes: SponsorTime[], index: number, hideHiddenSponsors = true): number {
-    // Only combine segments for AutoSkip
-    if (index == -1 || !shouldAutoSkip(sponsorTimes[index]) || sponsorTimes[index].actionType !== ActionType.Skip) {
-        return index;
-    }
-
-    // Default to the normal endTime
-    let latestEndTimeIndex = index;
-
-    for (let i = 0; i < sponsorTimes?.length; i++) {
-        const currentSegment = sponsorTimes[i].segment;
-        const latestEndTime = sponsorTimes[latestEndTimeIndex].segment[1];
-
-        if (
-            currentSegment[0] - skipBuffer <= latestEndTime &&
-            currentSegment[1] > latestEndTime &&
-            (!hideHiddenSponsors || sponsorTimes[i].hidden === SponsorHideType.Visible) &&
-            shouldAutoSkip(sponsorTimes[i]) &&
-            sponsorTimes[i].actionType === ActionType.Skip
-        ) {
-            // Overlapping segment
-            latestEndTimeIndex = i;
-        }
-    }
-
-    // Keep going if required
-    if (latestEndTimeIndex !== index) {
-        latestEndTimeIndex = getLatestEndTimeIndex(sponsorTimes, latestEndTimeIndex, hideHiddenSponsors);
-    }
-
-    return latestEndTimeIndex;
-}
-
-/**
- * Gets just the start times from a sponsor times array.
- * Optionally specify a minimum
- *
- * @param sponsorTimes
- * @param minimum
- * @param hideHiddenSponsors
- * @param includeIntersectingSegments If true, it will include segments that start before
- *  the current time, but end after
- */
-function getStartTimes(
-    sponsorTimes: SponsorTime[],
-    includeIntersectingSegments: boolean,
-    includeNonIntersectingSegments: boolean,
-    minimum?: number,
-    hideHiddenSponsors = false
-): { includedTimes: ScheduledTime[]; scheduledTimes: number[] } {
-    if (!sponsorTimes) return { includedTimes: [], scheduledTimes: [] };
-
-    const includedTimes: ScheduledTime[] = [];
-    const scheduledTimes: number[] = [];
-
-    const shouldIncludeTime = (segment: ScheduledTime) =>
-        (minimum === undefined ||
-            (includeNonIntersectingSegments && segment.scheduledTime >= minimum) ||
-            (includeIntersectingSegments &&
-                segment.scheduledTime < minimum &&
-                segment.segment[1] > minimum &&
-                shouldSkip(segment))) && // Only include intersecting skippable segments
-        (!hideHiddenSponsors || segment.hidden === SponsorHideType.Visible) &&
-        segment.segment.length === 2 &&
-        segment.actionType !== ActionType.Poi &&
-        segment.actionType !== ActionType.Full;
-
-    const possibleTimes = sponsorTimes.map((sponsorTime) => ({
-        ...sponsorTime,
-        scheduledTime: sponsorTime.segment[0],
-    }));
-
-    // Schedule at the end time to know when to unmute and remove title from seek bar
-    sponsorTimes.forEach((sponsorTime) => {
-        if (
-            !possibleTimes.some((time) => sponsorTime.segment[1] === time.scheduledTime && shouldIncludeTime(time)) &&
-            (minimum === undefined || sponsorTime.segment[1] > minimum)
-        ) {
-            possibleTimes.push({
-                ...sponsorTime,
-                scheduledTime: sponsorTime.segment[1],
-            });
-        }
-    });
-
-    for (let i = 0; i < possibleTimes.length; i++) {
-        if (shouldIncludeTime(possibleTimes[i])) {
-            scheduledTimes.push(possibleTimes[i].scheduledTime);
-            includedTimes.push(possibleTimes[i]);
-        }
-    }
-
-    return { includedTimes, scheduledTimes };
-}
-
-/**
- * Skip to exact time in a video and autoskips
- *
- * @param time
- */
-function previewTime(time: number, unpause = true) {
-    contentState.previewedSegment = true;
-    getVideo().currentTime = time;
-
-    // Unpause the video if needed
-    if (unpause && getVideo().paused) {
-        getVideo().play();
-    }
-}
-
-//send telemetry and count skip
-function sendTelemetryAndCount(skippingSegments: SponsorTime[], secondsSkipped: number, fullSkip: boolean) {
-    for (const segment of skippingSegments) {
-        if (!contentState.previewedSegment && contentState.sponsorTimesSubmitting.some((s) => s.segment === segment.segment)) {
-            // Count that as a previewed segment
-            contentState.previewedSegment = true;
-        }
-    }
-
-    if (
-        !Config.config.trackViewCount ||
-        (!Config.config.trackViewCountInPrivate && chrome.extension.inIncognitoContext)
-    )
-        return;
-
-    let counted = false;
-    for (const segment of skippingSegments) {
-        const index = contentState.sponsorTimes?.findIndex((s) => s.segment === segment.segment);
-        if (index !== -1 && !contentState.sponsorSkipped[index]) {
-            contentState.sponsorSkipped[index] = true;
-            if (!counted) {
-                Config.config.minutesSaved = Config.config.minutesSaved + secondsSkipped / 60;
-                Config.config.skipCount = Config.config.skipCount + 1;
-                counted = true;
-            }
-
-            if (fullSkip) asyncRequestToServer("POST", "/api/viewedVideoSponsorTime?UUID=" + segment.UUID);
-        }
-    }
-}
-
-//skip from the start time to the end time for a certain index sponsor time
-function skipToTime({ v, skipTime, skippingSegments, openNotice, forceAutoSkip, unskipTime }: SkipToTimeParams): void {
-    if (Config.config.disableSkipping) return;
-
-    let autoSkip: boolean;
-    if (sessionStorage.getItem("SKIPPING") === "false") {
-        sessionStorage.setItem("SKIPPING", "null");
-        autoSkip = false;
-    } else {
-        // There will only be one submission if it is manual skip
-        autoSkip = forceAutoSkip || shouldAutoSkip(skippingSegments[0]);
-    }
-
-    const isSubmittingSegment = contentState.sponsorTimesSubmitting.some((time) => time.segment === skippingSegments[0].segment);
-
-    if ((autoSkip || isSubmittingSegment) && v.currentTime !== skipTime[1]) {
-        switch (skippingSegments[0].actionType) {
-            case ActionType.Poi:
-            case ActionType.Skip: {
-                // Fix for looped videos not working when skipping to the end #426
-                // for some reason you also can't skip to 1 second before the end
-                if (v.loop && v.duration > 1 && skipTime[1] >= v.duration - 1) {
-                    v.currentTime = 0;
-                } else if (
-                    v.duration > 1 &&
-                    skipTime[1] >= v.duration &&
-                    (navigator.vendor === "Apple Computer, Inc." || isPlayingPlaylist())
-                ) {
-                    // MacOS will loop otherwise #1027
-                    // Sometimes playlists loop too #1804
-                    v.currentTime = v.duration - 0.001;
-                } else if (
-                    v.duration > 1 &&
-                    Math.abs(skipTime[1] - v.duration) < endTimeSkipBuffer &&
-                    isFirefoxOrSafari() &&
-                    !isSafari()
-                ) {
-                    v.currentTime = v.duration;
-                } else {
-                    if (inMuteSegment(skipTime[1], true)) {
-                        // Make sure not to mute if skipping into a mute segment
-                        v.muted = true;
-                        contentState.videoMuted = true;
-                    }
-
-                    v.currentTime = skipTime[1];
-                }
-
-                break;
-            }
-            case ActionType.Mute: {
-                if (!v.muted) {
-                    v.muted = true;
-                    contentState.videoMuted = true;
-                }
-                break;
-            }
-        }
-    }
-
-    if (autoSkip && Config.config.audioNotificationOnSkip && !isSubmittingSegment && !getVideo()?.muted) {
-        const beep = new Audio(chrome.runtime.getURL("icons/beep.ogg"));
-        beep.volume = getVideo().volume * 0.1;
-        const oldMetadata = navigator.mediaSession.metadata;
-        beep.play();
-        beep.addEventListener("ended", () => {
-            navigator.mediaSession.metadata = null;
-            setTimeout(() => {
-                navigator.mediaSession.metadata = oldMetadata;
-                beep.remove();
-            });
-        });
-    }
-
-    if (!autoSkip && skippingSegments.length === 1 && skippingSegments[0].actionType === ActionType.Poi) {
-        waitFor(() => contentState.skipButtonControlBar).then(() => {
-            contentState.skipButtonControlBar.enable(skippingSegments[0]);
-            if (Config.config.skipKeybind == null) contentState.skipButtonControlBar.setShowKeybindHint(false);
-
-            contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
-            contentState.activeSkipKeybindElement = contentState.skipButtonControlBar;
-        });
-    } else {
-        if (openNotice) {
-            //send out the message saying that a sponsor message was skipped
-            if (!Config.config.dontShowNotice || !autoSkip) {
-                createSkipNotice(skippingSegments, autoSkip, unskipTime, false);
-            } else if (autoSkip) {
-                contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
-                contentState.activeSkipKeybindElement = {
-                    setShowKeybindHint: () => { },
-                    toggleSkip: () => {
-                        createSkipNotice(skippingSegments, autoSkip, unskipTime, true);
-
-                        unskipSponsorTime(skippingSegments[0], unskipTime);
-                    },
-                };
-            }
-        }
-    }
-
-    //send telemetry that a this sponsor was skipped
-    if (autoSkip || isSubmittingSegment) sendTelemetryAndCount(skippingSegments, skipTime[1] - skipTime[0], true);
-}
-
-function createSkipNotice(
-    skippingSegments: SponsorTime[],
-    autoSkip: boolean,
-    unskipTime: number,
-    startReskip: boolean
-) {
-    for (const skipNotice of contentState.skipNotices) {
-        if (
-            skippingSegments.length === skipNotice.segments.length &&
-            skippingSegments.every((segment) => skipNotice.segments.some((s) => s.UUID === segment.UUID))
-        ) {
-            // Skip notice already exists
-            return;
-        }
-    }
-
-    const advanceSkipNoticeShow = !!contentState.advanceSkipNotices;
-    const newSkipNotice = new SkipNotice(
-        skippingSegments,
-        autoSkip,
-        skipNoticeContentContainer,
-        () => {
-            contentState.advanceSkipNotices?.close();
-            contentState.advanceSkipNotices = null;
-        },
-        unskipTime,
-        startReskip,
-        advanceSkipNoticeShow
-    );
-    if (Config.config.skipKeybind == null) newSkipNotice.setShowKeybindHint(false);
-    contentState.skipNotices.push(newSkipNotice);
-
-    contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
-    contentState.activeSkipKeybindElement = newSkipNotice;
-}
-
-function createAdvanceSkipNotice(
-    skippingSegments: SponsorTime[],
-    unskipTime: number,
-    autoSkip: boolean,
-    startReskip: boolean
-) {
-    if (contentState.advanceSkipNotices && !contentState.advanceSkipNotices.closed && contentState.advanceSkipNotices.sameNotice(skippingSegments)) {
-        return;
-    }
-
-    contentState.advanceSkipNotices?.close();
-    contentState.advanceSkipNotices = new advanceSkipNotice(
-        skippingSegments,
-        skipNoticeContentContainer,
-        unskipTime,
-        autoSkip,
-        startReskip
-    );
-    if (Config.config.skipKeybind == null) contentState.advanceSkipNotices.setShowKeybindHint(false);
-
-    contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
-    contentState.activeSkipKeybindElement = contentState.advanceSkipNotices;
-}
-
-function unskipSponsorTime(segment: SponsorTime, unskipTime: number = null, forceSeek = false) {
-    if (segment.actionType === ActionType.Mute) {
-        getVideo().muted = false;
-        contentState.videoMuted = false;
-    }
-
-    if (forceSeek || segment.actionType === ActionType.Skip) {
-        //add a tiny bit of time to make sure it is not skipped again
-        getVideo().currentTime = unskipTime ?? segment.segment[0] + 0.001;
-    }
-}
-
-function reskipSponsorTime(segment: SponsorTime, forceSeek = false) {
-    if (segment.actionType === ActionType.Mute && !forceSeek) {
-        getVideo().muted = true;
-        contentState.videoMuted = true;
-    } else {
-        const skippedTime = Math.max(segment.segment[1] - getVideo().currentTime, 0);
-        const segmentDuration = segment.segment[1] - segment.segment[0];
-        const fullSkip = skippedTime / segmentDuration > manualSkipPercentCount;
-
-        getVideo().currentTime = segment.segment[1];
-        sendTelemetryAndCount([segment], skippedTime, fullSkip);
-        startSponsorSchedule(true, segment.segment[1], false);
-    }
-}
-
-function shouldAutoSkip(segment: SponsorTime): boolean {
-    // danmaku segments are controlled by config
-    if (segment.source === SponsorSourceType.Danmaku) {
-        return Config.config.enableAutoSkipDanmakuSkip;
-    }
-    // Check if manual skip on full video is disabled or there is no full video segment for this category
-    if (
-        Config.config.manualSkipOnFullVideo &&
-        contentState.sponsorTimes?.some((s) => s.category === segment.category && s.actionType === ActionType.Full)
-    ) {
-        return false;
-    }
-
-    const categoryOption = utils.getCategorySelection(segment.category)?.option;
-
-    // Check if the category is set to AutoSkip
-    if (categoryOption === CategorySkipOption.AutoSkip) {
-        return true;
-    }
-    // Check if auto skip on music videos is enabled and there's a "music_offtopic" segment, and the current segment is of type Skip
-    else if (
-        Config.config.autoSkipOnMusicVideos &&
-        contentState.sponsorTimes?.some((s) => s.category === "music_offtopic") &&
-        segment.actionType === ActionType.Skip
-    ) {
-        return true;
-    }
-    // Check if this segment is in the submitting segments
-    else if (contentState.sponsorTimesSubmitting.some((s) => s.segment === segment.segment)) {
-        return true;
-    }
-
-    // Do not auto-skip in other cases
-    return false;
-}
-
-function shouldSkip(segment: SponsorTime): boolean {
-    return (
-        (segment.actionType !== ActionType.Full &&
-            segment.source !== SponsorSourceType.YouTube &&
-            utils.getCategorySelection(segment.category)?.option !== CategorySkipOption.ShowOverlay) ||
-        (Config.config.autoSkipOnMusicVideos &&
-            contentState.sponsorTimes?.some((s) => s.category === "music_offtopic") &&
-            segment.actionType === ActionType.Skip)
-    );
-}
 
 /** Creates any missing buttons on the player and updates their visiblity. */
 async function updateVisibilityOfPlayerControlsButton(): Promise<void> {

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,6 +1,6 @@
 import SkipNoticeComponent from "./components/SkipNoticeComponent";
 import Config from "./config";
-import { Keybind, keybindEquals, keybindToString, StorageChangesObject } from "./config/config";
+import { keybindToString, StorageChangesObject } from "./config/config";
 import { ContentContainer } from "./ContentContainerTypes";
 import PreviewBar, { PreviewBarSegment } from "./js-components/previewBar";
 import { SkipButtonControlBar } from "./js-components/skipButtonControlBar";
@@ -13,6 +13,8 @@ import {
     skipBuffer,
 } from "./content/state";
 import { danmakuForSkip, initDanmakuSkip } from "./content/danmakuSkip";
+import { initMessageHandler, setupMessageListener } from "./content/messageHandler";
+import { addHotkeyListener, initHotkeyHandler, seekFrameByKeyPressListener } from "./content/hotkeyHandler";
 import { Message, MessageResponse, VoteResponse } from "./messageTypes";
 import advanceSkipNotice from "./render/advanceSkipNotice";
 import { CategoryPill } from "./render/CategoryPill";
@@ -72,7 +74,6 @@ import {
     getBvID,
     getChannelIDInfo,
     getCid,
-    getFrameRate,
     getPageType,
     getVideo,
     getVideoID,
@@ -117,6 +118,8 @@ initDanmakuSkip({
     skipToTime,
     openSubmissionMenu,
 });
+
+initHotkeyHandler({ startOrEndTimingNewSegment, submitSegments, openSubmissionMenu, previewRecentSegment });
 
 setupVideoModule({ videoIDChange, channelIDChange, resetValues, videoElementChange });
 
@@ -2534,118 +2537,7 @@ function updateActiveSegment(currentTime: number): void {
     });
 }
 
-function addHotkeyListener(): void {
-    document.addEventListener("keydown", hotkeyListener);
-
-    const onLoad = () => {
-        // Allow us to stop propagation to Bilibili by being deeper
-        document.removeEventListener("keydown", hotkeyListener);
-        document.body.addEventListener("keydown", hotkeyListener);
-
-        addCleanupListener(() => {
-            document.body.removeEventListener("keydown", hotkeyListener);
-        });
-    };
-
-    if (document.readyState === "complete") {
-        onLoad();
-    } else {
-        document.addEventListener("DOMContentLoaded", onLoad);
-    }
-}
-
-function hotkeyListener(e: KeyboardEvent): void {
-    if (
-        ["textarea", "input"].includes(document.activeElement?.tagName?.toLowerCase()) ||
-        document.activeElement?.id?.toLowerCase()?.includes("editable")
-    )
-        return;
-
-    const key: Keybind = {
-        key: e.key,
-        code: e.code,
-        alt: e.altKey,
-        ctrl: e.ctrlKey,
-        shift: e.shiftKey,
-    };
-
-    const skipKey = Config.config.skipKeybind;
-    const skipToHighlightKey = Config.config.skipToHighlightKeybind;
-    const closeSkipNoticeKey = Config.config.closeSkipNoticeKeybind;
-    const startSponsorKey = Config.config.startSponsorKeybind;
-    const submitKey = Config.config.actuallySubmitKeybind;
-    const previewKey = Config.config.previewKeybind;
-    const openSubmissionMenuKey = Config.config.submitKeybind;
-
-    if (keybindEquals(key, skipKey)) {
-        if (contentState.activeSkipKeybindElement) {
-            contentState.activeSkipKeybindElement.toggleSkip.call(contentState.activeSkipKeybindElement);
-
-            /*
-             * 视频播放器全屏或网页全屏时，快捷键`Enter`会聚焦到弹幕输入框
-             * 这里阻止了使用`Enter`跳过赞助片段时播放器的默认行为
-             */
-            if (key.key === 'Enter') {
-                const currentTime: number | null = document.querySelector<HTMLVideoElement>(".bpx-player-video-wrap video")?.currentTime ?? null;
-                if (currentTime) {
-                    const inSponsorRange = contentState.sponsorTimes.some(({ segment: [start, end] }) => start <= currentTime && end >= currentTime);
-                    if (inSponsorRange) {
-                        utils.biliBiliPlayerDanmakuInputBlur();
-                    }
-                }
-
-            }
-        }
-
-        return;
-    } else if (keybindEquals(key, skipToHighlightKey)) {
-        if (contentState.skipButtonControlBar) {
-            contentState.skipButtonControlBar.toggleSkip.call(contentState.skipButtonControlBar);
-        }
-
-        return;
-    } else if (keybindEquals(key, closeSkipNoticeKey)) {
-        for (let i = 0; i < contentState.skipNotices.length; i++) {
-            contentState.skipNotices.pop().close();
-        }
-
-        return;
-    } else if (keybindEquals(key, startSponsorKey)) {
-        startOrEndTimingNewSegment();
-        return;
-    } else if (keybindEquals(key, submitKey)) {
-        submitSegments();
-        return;
-    } else if (keybindEquals(key, openSubmissionMenuKey)) {
-        e.preventDefault();
-
-        openSubmissionMenu();
-        return;
-    } else if (keybindEquals(key, previewKey)) {
-        previewRecentSegment();
-        return;
-    }
-}
-
-/**
- * Hot keys to jump to the next or previous frame, for easier segment time editting
- * only effective when the SubmissionNotice is open
- *
- * @param key keydown event
- */
-export function seekFrameByKeyPressListener(key) {
-    const vid = getVideo();
-    const frameRate = getFrameRate();
-    if (!vid.paused) return;
-
-    if (keybindEquals(key, Config.config.nextFrameKeybind)) {
-        // next frame
-        vid.currentTime += 1 / frameRate;
-    } else if (keybindEquals(key, Config.config.previousFrameKeybind)) {
-        // previous frame
-        vid.currentTime -= 1 / frameRate;
-    }
-}
+export { seekFrameByKeyPressListener } from "./content/hotkeyHandler";
 
 const durationID = "sponsorBlockDurationAfterSkips";
 function showTimeWithoutSkips(skippedDuration: number): void {

--- a/src/content.ts
+++ b/src/content.ts
@@ -8,7 +8,8 @@ import {
     getPageLoaded,
     setupPageLoadingListener,
 } from "./content/state";
-import { danmakuForSkip, initDanmakuSkip } from "./content/danmakuSkip";
+import { initDanmakuSkip } from "./content/danmakuSkip";
+import { initVideoListeners, setupVideoListeners } from "./content/videoListeners";
 import {
     checkPreviewbarState,
     createPreviewBar,
@@ -19,8 +20,6 @@ import {
     updatePreviewBar,
 } from "./content/previewBarManager";
 import {
-    cancelSponsorSchedule,
-    clearWaitingTime,
     getVirtualTime,
     initSkipScheduler,
     isSegmentMarkedNearCurrentTime,
@@ -30,8 +29,6 @@ import {
     startSkipScheduleCheckingForStartSponsors,
     startSponsorSchedule,
     unskipSponsorTime,
-    updateVirtualTime,
-    updateWaitingTime,
 } from "./content/skipScheduler";
 import { initMessageHandler, setupMessageListener } from "./content/messageHandler";
 import { addHotkeyListener, initHotkeyHandler, seekFrameByKeyPressListener } from "./content/hotkeyHandler";
@@ -66,7 +63,7 @@ import {
 import Utils from "./utils";
 import { waitFor } from "./utils/";
 import { AnimationUtils } from "./utils/animationUtils";
-import { addCleanupListener, cleanPage } from "./utils/cleanup";
+import { cleanPage } from "./utils/cleanup";
 import { defaultPreviewTime } from "./utils/constants";
 import { durationEquals } from "./utils/duraionUtils";
 import { getErrorMessage, getFormattedTime } from "./utils/formating";
@@ -129,6 +126,8 @@ initDanmakuSkip({
 initHotkeyHandler({ startOrEndTimingNewSegment, submitSegments, openSubmissionMenu, previewRecentSegment });
 
 initPreviewBarManager({ voteAsync, updateVisibilityOfPlayerControlsButton });
+
+initVideoListeners({ updateVisibilityOfPlayerControlsButton });
 
 setupVideoModule({ videoIDChange, channelIDChange, resetValues, videoElementChange });
 
@@ -282,220 +281,6 @@ async function videoIDChange(): Promise<void> {
     ) CommentListener();
 }
 
-/**
- * Triggered every time the video duration changes.
- * This happens when the resolution changes or at random time to clear memory.
- */
-function durationChangeListener(): void {
-    updatePreviewBar();
-}
-
-/**
- * Triggered once the video is ready.
- * This is mainly to attach to embedded players who don't have a video element visible.
- */
-function videoOnReadyListener(): void {
-    createPreviewBar();
-    updatePreviewBar();
-    updateVisibilityOfPlayerControlsButton();
-}
-
-
-let playbackRateCheckInterval: NodeJS.Timeout | null = null;
-let lastPlaybackSpeed = 1;
-let setupVideoListenersFirstTime = true;
-function setupVideoListeners(video: HTMLVideoElement) {
-    if (!video) return; // Maybe video became invisible
-
-    //wait until it is loaded
-    video.addEventListener("loadstart", videoOnReadyListener);
-    video.addEventListener("durationchange", durationChangeListener);
-
-    if (setupVideoListenersFirstTime) {
-        addCleanupListener(() => {
-            video.removeEventListener("loadstart", videoOnReadyListener);
-            video.removeEventListener("durationchange", durationChangeListener);
-        });
-    }
-
-    if (!Config.config.disableSkipping) {
-        danmakuForSkip();
-
-        contentState.switchingVideos = false;
-
-        let startedWaiting = false;
-        let lastPausedAtZero = true;
-
-        const rateChangeListener = () => {
-            updateVirtualTime();
-            clearWaitingTime();
-
-            startSponsorSchedule();
-        };
-        video.addEventListener("ratechange", rateChangeListener);
-        // Used by videospeed extension (https://github.com/igrigorik/videospeed/pull/740)
-        video.addEventListener("videoSpeed_ratechange", rateChangeListener);
-
-        const playListener = () => {
-            // If it is not the first event, then the only way to get to 0 is if there is a seek event
-            // This check makes sure that changing the video resolution doesn't cause the extension to think it
-            // gone back to the begining
-            if (video.readyState <= HTMLMediaElement.HAVE_CURRENT_DATA && video.currentTime === 0) return;
-
-            updateVirtualTime();
-
-            if (contentState.switchingVideos || lastPausedAtZero) {
-                contentState.switchingVideos = false;
-                logDebug("Setting switching videos to false");
-
-                // If already segments loaded before video, retry to skip starting segments
-                if (contentState.sponsorTimes) startSkipScheduleCheckingForStartSponsors();
-            }
-
-            lastPausedAtZero = false;
-
-            // Make sure it doesn't get double called with the playing event
-            if (
-                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
-                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
-            ) {
-                contentState.lastCheckTime = Date.now();
-                contentState.lastCheckVideoTime = video.currentTime;
-
-                startSponsorSchedule();
-            }
-        };
-        video.addEventListener("play", playListener);
-
-        const playingListener = () => {
-            updateVirtualTime();
-            lastPausedAtZero = false;
-
-            if (startedWaiting) {
-                startedWaiting = false;
-                logDebug(
-                    `[SB] Playing event after buffering: ${Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
-                    (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
-                    }`
-                );
-            }
-
-            if (contentState.switchingVideos) {
-                contentState.switchingVideos = false;
-                logDebug("Setting switching videos to false");
-
-                // If already segments loaded before video, retry to skip starting segments
-                if (contentState.sponsorTimes) startSkipScheduleCheckingForStartSponsors();
-            }
-
-            // Make sure it doesn't get double called with the play event
-            if (
-                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
-                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
-            ) {
-                contentState.lastCheckTime = Date.now();
-                contentState.lastCheckVideoTime = video.currentTime;
-
-                startSponsorSchedule();
-            }
-
-            if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
-            lastPlaybackSpeed = video.playbackRate;
-
-            // Video speed controller compatibility
-            // That extension makes rate change events not propagate
-            if (document.body.classList.contains("vsc-initialized")) {
-                playbackRateCheckInterval = setInterval(() => {
-                    if ((!getVideoID() || video.paused) && playbackRateCheckInterval) {
-                        // Video is gone, stop checking
-                        clearInterval(playbackRateCheckInterval);
-                        return;
-                    }
-
-                    if (video.playbackRate !== lastPlaybackSpeed) {
-                        lastPlaybackSpeed = video.playbackRate;
-
-                        rateChangeListener();
-                    }
-                }, 2000);
-            }
-        };
-        video.addEventListener("playing", playingListener);
-
-        const seekingListener = () => {
-            contentState.lastKnownVideoTime.fromPause = false;
-
-            if (!video.paused) {
-                // Reset lastCheckVideoTime
-                contentState.lastCheckTime = Date.now();
-                contentState.lastCheckVideoTime = video.currentTime;
-
-                updateVirtualTime();
-                clearWaitingTime();
-
-                // Sometimes looped videos loop back to almost zero, but not quite
-                if (video.loop && video.currentTime < 0.2) {
-                    startSponsorSchedule(false, 0);
-                } else {
-                    // Include intersecting segments so that seeking into the middle of a segment still triggers a skip
-                    startSponsorSchedule(Config.config.skipOnSeekToSegment);
-                }
-            } else {
-                updateActiveSegment(video.currentTime);
-
-                if (video.currentTime === 0) {
-                    lastPausedAtZero = true;
-                }
-            }
-        };
-        video.addEventListener("seeking", seekingListener);
-
-        const stoppedPlayback = () => {
-            // Reset lastCheckVideoTime
-            contentState.lastCheckVideoTime = -1;
-            contentState.lastCheckTime = 0;
-
-            if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
-
-            contentState.lastKnownVideoTime.videoTime = null;
-            contentState.lastKnownVideoTime.preciseTime = null;
-            updateWaitingTime();
-
-            cancelSponsorSchedule();
-        };
-        const pauseListener = () => {
-            contentState.lastKnownVideoTime.fromPause = true;
-
-            stoppedPlayback();
-        };
-        video.addEventListener("pause", pauseListener);
-        const waitingListener = () => {
-            logDebug("[SB] Not skipping due to buffering");
-            startedWaiting = true;
-
-            stoppedPlayback();
-        };
-        video.addEventListener("waiting", waitingListener);
-
-        startSponsorSchedule();
-
-        if (setupVideoListenersFirstTime) {
-            addCleanupListener(() => {
-                video.removeEventListener("play", playListener);
-                video.removeEventListener("playing", playingListener);
-                video.removeEventListener("seeking", seekingListener);
-                video.removeEventListener("ratechange", rateChangeListener);
-                video.removeEventListener("videoSpeed_ratechange", rateChangeListener);
-                video.removeEventListener("pause", pauseListener);
-                video.removeEventListener("waiting", waitingListener);
-
-                if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
-            });
-        }
-    }
-
-    setupVideoListenersFirstTime = false;
-}
 
 
 function setupSkipButtonControlBar() {

--- a/src/content.ts
+++ b/src/content.ts
@@ -4,6 +4,14 @@ import { Keybind, keybindEquals, keybindToString, StorageChangesObject } from ".
 import { ContentContainer } from "./ContentContainerTypes";
 import PreviewBar, { PreviewBarSegment } from "./js-components/previewBar";
 import { SkipButtonControlBar } from "./js-components/skipButtonControlBar";
+import {
+    contentState,
+    endTimeSkipBuffer,
+    getPageLoaded,
+    manualSkipPercentCount,
+    setupPageLoadingListener,
+    skipBuffer,
+} from "./content/state";
 import { Message, MessageResponse, VoteResponse } from "./messageTypes";
 import advanceSkipNotice from "./render/advanceSkipNotice";
 import { CategoryPill } from "./render/CategoryPill";
@@ -36,8 +44,6 @@ import {
     SponsorHideType,
     SponsorSourceType,
     SponsorTime,
-    ToggleSkippable,
-    VideoInfo,
     YTID,
 } from "./types";
 import Utils from "./utils";
@@ -52,7 +58,7 @@ import { importTimes } from "./utils/exporter";
 import { getErrorMessage, getFormattedTime } from "./utils/formating";
 import { GenericUtils } from "./utils/genericUtils";
 import { getHash, getVideoIDHash, HashedValue } from "./utils/hash";
-import { getCidMapFromWindow, sourceId } from "./utils/injectedScriptMessageUtils";
+import { getCidMapFromWindow } from "./utils/injectedScriptMessageUtils";
 import { logDebug } from "./utils/logger";
 import { getControls, getHashParams, getProgressBar, isPlayingPlaylist } from "./utils/pageUtils";
 import { getBilibiliVideoID } from "./utils/parseVideoID";
@@ -102,52 +108,6 @@ if ((document.hidden && getPageType() == PageType.Video) || ([PageType.Video, Pa
     window.addEventListener("mouseover", () => videoElementChange(true, getVideo()), { once: true });
 }
 
-const skipBuffer = 0.003;
-// If this close to the end, skip to the end
-const endTimeSkipBuffer = 0.5;
-
-//was sponsor data found when doing SponsorsLookup
-let sponsorDataFound = false;
-//the actual sponsorTimes if loaded and UUIDs associated with them
-let sponsorTimes: SponsorTime[] = [];
-// List of open skip notices
-const skipNotices: SkipNotice[] = [];
-let advanceSkipNotices: advanceSkipNotice | null = null;
-let activeSkipKeybindElement: ToggleSkippable = null;
-let shownSegmentFailedToFetchWarning = false;
-let selectedSegment: SegmentUUID | null = null;
-let previewedSegment = false;
-
-let portVideo: PortVideo = null;
-
-// JSON video info
-let videoInfo: VideoInfo = null;
-// Locked Categories in this tab, like: ["sponsor","intro","outro"]
-let lockedCategories: Category[] = [];
-// Used to calculate a more precise "virtual" video time
-const lastKnownVideoTime: { videoTime: number; preciseTime: number; fromPause: boolean; approximateDelay: number } = {
-    videoTime: null,
-    preciseTime: null,
-    fromPause: false,
-    approximateDelay: null,
-};
-// It resumes with a slightly later time on chromium
-let lastTimeFromWaitingEvent: number = null;
-
-// Skips are scheduled to ensure precision.
-// Skips are rescheduled every seeking event.
-// Skips are canceled every seeking event
-let currentSkipSchedule: NodeJS.Timeout = null;
-let currentSkipInterval: NodeJS.Timeout = null;
-let currentVirtualTimeInterval: NodeJS.Timeout = null;
-let currentadvanceSkipSchedule: NodeJS.Timeout = null;
-
-/** Has the sponsor been skipped */
-let sponsorSkipped: boolean[] = [];
-
-let videoMuted = false; // Has it been attempted to be muted
-
-let pageLoaded = false;
 setupPageLoadingListener();
 
 setupVideoModule({ videoIDChange, channelIDChange, resetValues, videoElementChange });
@@ -165,117 +125,33 @@ const playerButton = new PlayerButton(
     openInfoMenu
 );
 
-/**
- *  Wait for the page to be truly available (Vue mount/hydration completed) before allowing the plugin to operate on the DOM.
- *
- *  Primary: Listen for "pageReady" messages from MAIN world
- *  Fallback: If no message is received within 30s, use readyState=complete + 2s delay fallback
- */
-function setupPageLoadingListener(): void {
-    const TAG = "[BSB-pageReady]";
-    const t0 = performance.now();
+export { getPageLoaded } from "./content/state";
 
-    let resolved = false;
-    const markReady = (reason: string) => {
-        if (resolved) return;
-        resolved = true;
-        const elapsed = Math.round(performance.now() - t0);
-        console.debug(`${TAG} Page ready (${reason}) at +${elapsed}ms`);
-        pageLoaded = true;
-    };
-
-    // Primary: listen for Vue-mount notification from MAIN world (document.ts)
-    window.addEventListener("message", (e: MessageEvent) => {
-        if (e.data?.source === sourceId && e.data?.type === "pageReady") {
-            markReady("vue-mount signal from MAIN world");
-        }
-    });
-
-    // Fallback: if the MAIN world signal never arrives (e.g. document.js
-    // failed to load, or a page type that doesn't mount Vue on #app),
-    // fall back to readyState=complete + 2 s delay.
-    const FALLBACK_TIMEOUT = 30000;
-    setTimeout(() => {
-        if (!resolved) {
-            if (document.readyState === "complete") {
-                markReady(`fallback: readyState already complete after ${FALLBACK_TIMEOUT}ms`);
-            } else {
-                window.addEventListener("load", () => {
-                    setTimeout(() => markReady("fallback: window.load + 2s delay"), 2000);
-                }, { once: true });
-            }
-        }
-    }, FALLBACK_TIMEOUT);
-}
-
-export function getPageLoaded() {
-    return pageLoaded;
-}
-
-//the video id of the last preview bar update
-let lastPreviewBarUpdate: BVID;
-
-// Is the video currently being switched
-let switchingVideos = null;
-
-// Used by the play and playing listeners to make sure two aren't
-// called at the same time
-let lastCheckTime = 0;
-let lastCheckVideoTime = -1;
-
-//is this channel whitelised from getting sponsors skipped
-let channelWhitelisted = false;
-
-let previewBar: PreviewBar = null;
-// Skip to highlight button
-let skipButtonControlBar: SkipButtonControlBar = null;
-// For full video sponsors/selfpromo
-let categoryPill: CategoryPill = null;
-
-let descriptionPill: DescriptionPortPill = null;
-
-/** Contains buttons created by `createButton()`. */
-let playerButtons: Record<string, { button: HTMLButtonElement; image: HTMLImageElement }> = {};
 
 addHotkeyListener();
 
-/** Segments created by the user which have not yet been submitted. */
-let sponsorTimesSubmitting: SponsorTime[] = [];
-let loadedPreloadedSegment = false;
-
-//becomes true when isInfoFound is called
-//this is used to close the popup on Bilibili when the other popup opens
-let popupInitialised = false;
-
-let submissionNotice: SubmissionNotice = null;
-
-let lastResponseStatus: number;
-let lookupWaiting = false;
 
 // Contains all of the functions and variables needed by the skip notice
 const skipNoticeContentContainer: ContentContainer = () => ({
     vote,
     dontShowNoticeAgain,
     unskipSponsorTime,
-    sponsorTimes,
-    sponsorTimesSubmitting,
-    skipNotices,
-    advanceSkipNotices,
+    sponsorTimes: contentState.sponsorTimes,
+    sponsorTimesSubmitting: contentState.sponsorTimesSubmitting,
+    skipNotices: contentState.skipNotices,
+    advanceSkipNotices: contentState.advanceSkipNotices,
     sponsorVideoID: getVideoID(),
     reskipSponsorTime,
     updatePreviewBar,
-    sponsorSubmissionNotice: submissionNotice,
+    sponsorSubmissionNotice: contentState.submissionNotice,
     resetSponsorSubmissionNotice,
     updateEditButtonsOnPlayer: updateSegmentSubmitting,
     previewTime,
-    videoInfo,
+    videoInfo: contentState.videoInfo,
     getRealCurrentTime: getRealCurrentTime,
-    lockedCategories,
+    lockedCategories: contentState.lockedCategories,
     channelIDInfo: getChannelIDInfo(),
 });
-
-// value determining when to count segment as skipped and send telemetry to server (percent based)
-const manualSkipPercentCount = 0.5;
 
 //get messages from the background script and the popup
 chrome.runtime.onMessage.addListener(messageListener);
@@ -299,27 +175,27 @@ async function messageListener(
 
             break;
         case "isInfoFound":
-            if (!lastResponseStatus) return;
+            if (!contentState.lastResponseStatus) return;
 
             //send the sponsor times along with if it's found
             sendResponse({
-                found: sponsorDataFound,
-                status: lastResponseStatus,
-                sponsorTimes: sponsorTimes,
-                portVideo: portVideo,
+                found: contentState.sponsorDataFound,
+                status: contentState.lastResponseStatus,
+                sponsorTimes: contentState.sponsorTimes,
+                portVideo: contentState.portVideo,
                 time: getVideo()?.currentTime ?? 0,
             });
 
             if (
                 !request.updating &&
-                popupInitialised &&
+                contentState.popupInitialised &&
                 document.getElementById("sponsorBlockPopupContainer") != null
             ) {
                 //the popup should be closed now that another is opening
                 closeInfoMenu();
             }
 
-            popupInitialised = true;
+            contentState.popupInitialised = true;
             break;
         case "getVideoID":
             {
@@ -361,12 +237,12 @@ async function messageListener(
             break;
         case "isChannelWhitelisted":
             sendResponse({
-                value: channelWhitelisted,
+                value: contentState.channelWhitelisted,
             });
 
             break;
         case "whitelistChange":
-            channelWhitelisted = request.value;
+            contentState.channelWhitelisted = request.value;
             sponsorsLookup();
 
             break;
@@ -388,14 +264,14 @@ async function messageListener(
             break;
         case "unskip":
             unskipSponsorTime(
-                sponsorTimes.find((segment) => segment.UUID === request.UUID),
+                contentState.sponsorTimes.find((segment) => segment.UUID === request.UUID),
                 null,
                 true
             );
             break;
         case "reskip":
             reskipSponsorTime(
-                sponsorTimes.find((segment) => segment.UUID === request.UUID),
+                contentState.sponsorTimes.find((segment) => segment.UUID === request.UUID),
                 true
             );
             break;
@@ -406,17 +282,17 @@ async function messageListener(
             vote(request.type, request.UUID).then((response) => sendResponse(response));
             return true;
         case "hideSegment":
-            utils.getSponsorTimeFromUUID(sponsorTimes, request.UUID).hidden = request.type;
+            utils.getSponsorTimeFromUUID(contentState.sponsorTimes, request.UUID).hidden = request.type;
             utils.addHiddenSegment(getVideoID(), request.UUID, request.type);
             updatePreviewBar();
 
             if (
-                skipButtonControlBar?.isEnabled() &&
-                sponsorTimesSubmitting.every(
+                contentState.skipButtonControlBar?.isEnabled() &&
+                contentState.sponsorTimesSubmitting.every(
                     (s) => s.hidden !== SponsorHideType.Visible || s.actionType !== ActionType.Poi
                 )
             ) {
-                skipButtonControlBar.disable();
+                contentState.skipButtonControlBar.disable();
             }
             break;
         case "closePopup":
@@ -430,19 +306,19 @@ async function messageListener(
             let addedSegments = false;
             for (const segment of importedSegments) {
                 if (
-                    !sponsorTimesSubmitting.some(
+                    !contentState.sponsorTimesSubmitting.some(
                         (s) =>
                             Math.abs(s.segment[0] - segment.segment[0]) < 1 &&
                             Math.abs(s.segment[1] - segment.segment[1]) < 1
                     )
                 ) {
-                    sponsorTimesSubmitting.push(segment);
+                    contentState.sponsorTimesSubmitting.push(segment);
                     addedSegments = true;
                 }
             }
 
             if (addedSegments) {
-                Config.local.unsubmittedSegments[getVideoID()] = sponsorTimesSubmitting;
+                Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
                 Config.forceLocalUpdate("unsubmittedSegments");
 
                 updateSegmentSubmitting();
@@ -513,54 +389,54 @@ if (!Config.configSyncListeners.includes(contentConfigUpdateListener)) {
 }
 
 function resetValues() {
-    lastCheckTime = 0;
-    lastCheckVideoTime = -1;
-    previewedSegment = false;
+    contentState.lastCheckTime = 0;
+    contentState.lastCheckVideoTime = -1;
+    contentState.previewedSegment = false;
 
-    sponsorTimes = [];
-    sponsorSkipped = [];
-    lastResponseStatus = 0;
-    shownSegmentFailedToFetchWarning = false;
+    contentState.sponsorTimes = [];
+    contentState.sponsorSkipped = [];
+    contentState.lastResponseStatus = 0;
+    contentState.shownSegmentFailedToFetchWarning = false;
 
-    videoInfo = null;
-    channelWhitelisted = false;
-    lockedCategories = [];
+    contentState.videoInfo = null;
+    contentState.channelWhitelisted = false;
+    contentState.lockedCategories = [];
 
     //empty the preview bar
-    if (previewBar !== null) {
-        previewBar.clear();
+    if (contentState.previewBar !== null) {
+        contentState.previewBar.clear();
     }
 
     // resetDurationAfterSkip
     removeDurationAfterSkip();
 
     //reset sponsor data found check
-    sponsorDataFound = false;
+    contentState.sponsorDataFound = false;
 
-    if (switchingVideos === null) {
+    if (contentState.switchingVideos === null) {
         // When first loading a video, it is not switching videos
-        switchingVideos = false;
+        contentState.switchingVideos = false;
     } else {
-        switchingVideos = true;
+        contentState.switchingVideos = true;
         logDebug("Setting switching videos to true (reset data)");
     }
 
-    skipButtonControlBar?.disable();
-    categoryPill?.resetSegment();
+    contentState.skipButtonControlBar?.disable();
+    contentState.categoryPill?.resetSegment();
 
-    for (let i = 0; i < skipNotices.length; i++) {
-        skipNotices.pop()?.close();
+    for (let i = 0; i < contentState.skipNotices.length; i++) {
+        contentState.skipNotices.pop()?.close();
     }
 
-    if (advanceSkipNotices) {
-        advanceSkipNotices.close();
-        advanceSkipNotices = null;
+    if (contentState.advanceSkipNotices) {
+        contentState.advanceSkipNotices.close();
+        contentState.advanceSkipNotices = null;
     }
 }
 
 async function videoIDChange(): Promise<void> {
     //setup the preview bar
-    if (previewBar === null) {
+    if (contentState.previewBar === null) {
         waitFor(getControls).then(createPreviewBar);
     }
 
@@ -568,14 +444,14 @@ async function videoIDChange(): Promise<void> {
     chrome.runtime.sendMessage({
         message: "videoChanged",
         videoID: getVideoID(),
-        whitelisted: channelWhitelisted,
+        whitelisted: contentState.channelWhitelisted,
     });
 
     sponsorsLookup();
     checkPageForNewThumbnails();
 
     // Clear unsubmitted segments from the previous video
-    sponsorTimesSubmitting = [];
+    contentState.sponsorTimesSubmitting = [];
     updateSponsorTimesSubmitting();
 
     // TODO use mutation observer to get the reloading of the video element
@@ -597,7 +473,7 @@ async function videoIDChange(): Promise<void> {
  * Creates a preview bar on the video
  */
 function createPreviewBar(): void {
-    if (previewBar !== null) return;
+    if (contentState.previewBar !== null) return;
 
     const progressElementOptions = [
         {
@@ -616,7 +492,7 @@ function createPreviewBar(): void {
 
         if (parent) {
             const chapterVote = new ChapterVote(voteAsync);
-            previewBar = new PreviewBar(parent, shadowParent, chapterVote);
+            contentState.previewBar = new PreviewBar(parent, shadowParent, chapterVote);
             updatePreviewBar();
             break;
         }
@@ -644,19 +520,19 @@ function videoOnReadyListener(): void {
 function cancelSponsorSchedule(): void {
     logDebug("Pausing skipping");
 
-    if (currentSkipSchedule !== null) {
-        clearTimeout(currentSkipSchedule);
-        currentSkipSchedule = null;
+    if (contentState.currentSkipSchedule !== null) {
+        clearTimeout(contentState.currentSkipSchedule);
+        contentState.currentSkipSchedule = null;
     }
 
-    if (currentSkipInterval !== null) {
-        clearInterval(currentSkipInterval);
-        currentSkipInterval = null;
+    if (contentState.currentSkipInterval !== null) {
+        clearInterval(contentState.currentSkipInterval);
+        contentState.currentSkipInterval = null;
     }
 
-    if (currentadvanceSkipSchedule !== null) {
-        clearInterval(currentadvanceSkipSchedule);
-        currentadvanceSkipSchedule = null;
+    if (contentState.currentadvanceSkipSchedule !== null) {
+        clearInterval(contentState.currentadvanceSkipSchedule);
+        contentState.currentadvanceSkipSchedule = null;
     }
 }
 
@@ -694,16 +570,16 @@ async function startSponsorSchedule(
     const videoID = getVideoID();
 
     if (
-        videoMuted &&
+        contentState.videoMuted &&
         !inMuteSegment(
             currentTime,
             skipInfo.index !== -1 && timeUntilSponsor < skipBuffer && shouldAutoSkip(currentSkip)
         )
     ) {
         video.muted = false;
-        videoMuted = false;
+        contentState.videoMuted = false;
 
-        for (const notice of skipNotices) {
+        for (const notice of contentState.skipNotices) {
             // So that the notice can hide buttons
             notice.unmutedListener(currentTime);
         }
@@ -714,7 +590,7 @@ async function startSponsorSchedule(
 
     if (
         Config.config.disableSkipping ||
-        channelWhitelisted ||
+        contentState.channelWhitelisted ||
         (getChannelIDInfo().status === ChannelIDStatus.Fetching && Config.config.forceChannelCheck)
     ) {
         return;
@@ -741,7 +617,7 @@ async function startSponsorSchedule(
     }
 
     logDebug(
-        `Next step in starting skipping: ${!shouldSkip(currentSkip)}, ${!sponsorTimesSubmitting?.some(
+        `Next step in starting skipping: ${!shouldSkip(currentSkip)}, ${!contentState.sponsorTimesSubmitting?.some(
             (segment) => segment.segment === currentSkip.segment
         )}`
     );
@@ -756,7 +632,7 @@ async function startSponsorSchedule(
 
         if (
             shouldSkip(currentSkip) ||
-            sponsorTimesSubmitting?.some((segment) => segment.segment === currentSkip.segment)
+            contentState.sponsorTimesSubmitting?.some((segment) => segment.segment === currentSkip.segment)
         ) {
             if (forceVideoTime >= skipTime[0] - skipBuffer && forceVideoTime < skipTime[1]) {
                 skipToTime({
@@ -827,24 +703,24 @@ async function startSponsorSchedule(
             const reportedVideoTimeAtStart = getVideo().currentTime;
             logDebug(`Starting setInterval skipping ${getVideo().currentTime} to skip at ${skipTime[0]}`);
 
-            if (currentSkipInterval !== null) clearInterval(currentSkipInterval);
-            currentSkipInterval = setInterval(() => {
+            if (contentState.currentSkipInterval !== null) clearInterval(contentState.currentSkipInterval);
+            contentState.currentSkipInterval = setInterval(() => {
                 // Estimate delay, but only take the current time right after a change
                 // Current time remains the same for many "frames" on Firefox
                 if (
                     isFirefoxOrSafari() &&
-                    !lastKnownVideoTime.fromPause &&
+                    !contentState.lastKnownVideoTime.fromPause &&
                     startWaitingForReportedTimeToChange &&
                     reportedVideoTimeAtStart !== getVideo().currentTime
                 ) {
                     startWaitingForReportedTimeToChange = false;
                     const delay = getVirtualTime() - getVideo().currentTime;
-                    if (delay > 0) lastKnownVideoTime.approximateDelay = delay;
+                    if (delay > 0) contentState.lastKnownVideoTime.approximateDelay = delay;
                 }
 
                 const intervalDuration = performance.now() - startIntervalTime;
                 if (intervalDuration + skipBuffer * 1000 >= delayTime || getVideo().currentTime >= skipTime[0]) {
-                    clearInterval(currentSkipInterval);
+                    clearInterval(contentState.currentSkipInterval);
                     if (!isFirefoxOrSafari() && !getVideo().muted && !inMuteSegment(getVideo().currentTime, true)) {
                         // Workaround for more accurate skipping on Chromium
                         getVideo().muted = true;
@@ -865,13 +741,13 @@ async function startSponsorSchedule(
             const offset = isFirefoxOrSafari() && !isSafari() ? 600 : 150;
             // Schedule for right before to be more precise than normal timeout
             const offsetDelayTime = Math.max(0, delayTime - offset);
-            currentSkipSchedule = setTimeout(skippingFunction, offsetDelayTime);
+            contentState.currentSkipSchedule = setTimeout(skippingFunction, offsetDelayTime);
 
             if (
                 Config.config.advanceSkipNotice &&
                 Config.config.skipNoticeDurationBefore > 0 &&
                 getVideo().currentTime < skippingSegments[0].segment[0] &&
-                !sponsorTimesSubmitting?.some((segment) => segment.segment === currentSkip.segment) &&
+                !contentState.sponsorTimesSubmitting?.some((segment) => segment.segment === currentSkip.segment) &&
                 [ActionType.Skip, ActionType.Mute].includes(skippingSegments[0].actionType) &&
                 shouldAutoSkip(skippingSegments[0]) &&
                 !getVideo()?.paused
@@ -880,8 +756,8 @@ async function startSponsorSchedule(
                 const timeUntilPopup = Math.max(0, offsetDelayTime - maxPopupTime);
                 const autoSkip = shouldAutoSkip(skippingSegments[0]);
 
-                if (currentadvanceSkipSchedule) clearTimeout(currentadvanceSkipSchedule);
-                currentadvanceSkipSchedule = setTimeout(() => {
+                if (contentState.currentadvanceSkipSchedule) clearTimeout(contentState.currentadvanceSkipSchedule);
+                contentState.currentadvanceSkipSchedule = setTimeout(() => {
                     createAdvanceSkipNotice([skippingSegments[0]], skipTime[0], autoSkip, false);
                     sessionStorage.setItem("SKIPPING", "true");
                 }, timeUntilPopup);
@@ -927,8 +803,8 @@ function checkDanmaku(text: string, offset: number) {
         });
         if (Config.config.enableMenuDanmakuSkip) {
             setTimeout(() => {
-                if (!sponsorTimesSubmitting?.some((s) => s.segment[1] === skippingSegments[0].segment[1])) {
-                    sponsorTimesSubmitting.push(skippingSegments[0]);
+                if (!contentState.sponsorTimesSubmitting?.some((s) => s.segment[1] === skippingSegments[0].segment[1])) {
+                    contentState.sponsorTimesSubmitting.push(skippingSegments[0]);
                 }
                 openSubmissionMenu();
             }, Config.config.skipNoticeDuration * 1000 + 500);
@@ -991,10 +867,10 @@ function waitForNextTimeChange(): Promise<DOMHighResTimeStamp | null> {
 
 function getVirtualTime(): number {
     const virtualTime =
-        lastTimeFromWaitingEvent ??
-        (lastKnownVideoTime.videoTime !== null
-            ? ((performance.now() - lastKnownVideoTime.preciseTime) * getVideo().playbackRate) / 1000 +
-            lastKnownVideoTime.videoTime
+        contentState.lastTimeFromWaitingEvent ??
+        (contentState.lastKnownVideoTime.videoTime !== null
+            ? ((performance.now() - contentState.lastKnownVideoTime.preciseTime) * getVideo().playbackRate) / 1000 +
+            contentState.lastKnownVideoTime.videoTime
             : null);
 
     if (
@@ -1016,14 +892,14 @@ function inMuteSegment(currentTime: number, includeOverlap: boolean): boolean {
         segment.hidden === SponsorHideType.Visible &&
         segment.segment[0] <= currentTime &&
         (segment.segment[1] > currentTime || (includeOverlap && segment.segment[1] + 0.02 > currentTime));
-    return sponsorTimes?.some(checkFunction) || sponsorTimesSubmitting.some(checkFunction);
+    return contentState.sponsorTimes?.some(checkFunction) || contentState.sponsorTimesSubmitting.some(checkFunction);
 }
 
 function isSegmentMarkedNearCurrentTime(currentTime: number, range: number = 5): boolean {
     const lowerBound = currentTime - range;
     const upperBound = currentTime + range;
 
-    return sponsorTimes?.some((sponsorTime) => {
+    return contentState.sponsorTimes?.some((sponsorTime) => {
         const {
             segment: [startTime, endTime],
         } = sponsorTime;
@@ -1040,11 +916,11 @@ async function incorrectVideoCheck(videoID?: string, sponsorTime?: SponsorTime):
     if (
         currentVideoID !== recordedVideoID ||
         (sponsorTime &&
-            (!sponsorTimes ||
-                !sponsorTimes?.some(
+            (!contentState.sponsorTimes ||
+                !contentState.sponsorTimes?.some(
                     (time) => time.segment[0] === sponsorTime.segment[0] && time.segment[1] === sponsorTime.segment[1]
                 )) &&
-            !sponsorTimesSubmitting.some(
+            !contentState.sponsorTimesSubmitting.some(
                 (time) => time.segment[0] === sponsorTime.segment[0] && time.segment[1] === sponsorTime.segment[1]
             ))
     ) {
@@ -1055,9 +931,9 @@ async function incorrectVideoCheck(videoID?: string, sponsorTime?: SponsorTime):
             "[SponsorBlock] SponsorTime",
             sponsorTime,
             "sponsorTimes",
-            sponsorTimes,
+            contentState.sponsorTimes,
             "sponsorTimesSubmitting",
-            sponsorTimesSubmitting
+            contentState.sponsorTimesSubmitting
         );
 
         // Video ID change occured
@@ -1089,7 +965,7 @@ function setupVideoListeners(video: HTMLVideoElement) {
     if (!Config.config.disableSkipping) {
         danmakuForSkip();
 
-        switchingVideos = false;
+        contentState.switchingVideos = false;
 
         let startedWaiting = false;
         let lastPausedAtZero = true;
@@ -1112,23 +988,23 @@ function setupVideoListeners(video: HTMLVideoElement) {
 
             updateVirtualTime();
 
-            if (switchingVideos || lastPausedAtZero) {
-                switchingVideos = false;
+            if (contentState.switchingVideos || lastPausedAtZero) {
+                contentState.switchingVideos = false;
                 logDebug("Setting switching videos to false");
 
                 // If already segments loaded before video, retry to skip starting segments
-                if (sponsorTimes) startSkipScheduleCheckingForStartSponsors();
+                if (contentState.sponsorTimes) startSkipScheduleCheckingForStartSponsors();
             }
 
             lastPausedAtZero = false;
 
             // Make sure it doesn't get double called with the playing event
             if (
-                Math.abs(lastCheckVideoTime - video.currentTime) > 0.3 ||
-                (lastCheckVideoTime !== video.currentTime && Date.now() - lastCheckTime > 2000)
+                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
+                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
             ) {
-                lastCheckTime = Date.now();
-                lastCheckVideoTime = video.currentTime;
+                contentState.lastCheckTime = Date.now();
+                contentState.lastCheckVideoTime = video.currentTime;
 
                 startSponsorSchedule();
             }
@@ -1142,27 +1018,27 @@ function setupVideoListeners(video: HTMLVideoElement) {
             if (startedWaiting) {
                 startedWaiting = false;
                 logDebug(
-                    `[SB] Playing event after buffering: ${Math.abs(lastCheckVideoTime - video.currentTime) > 0.3 ||
-                    (lastCheckVideoTime !== video.currentTime && Date.now() - lastCheckTime > 2000)
+                    `[SB] Playing event after buffering: ${Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
+                    (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
                     }`
                 );
             }
 
-            if (switchingVideos) {
-                switchingVideos = false;
+            if (contentState.switchingVideos) {
+                contentState.switchingVideos = false;
                 logDebug("Setting switching videos to false");
 
                 // If already segments loaded before video, retry to skip starting segments
-                if (sponsorTimes) startSkipScheduleCheckingForStartSponsors();
+                if (contentState.sponsorTimes) startSkipScheduleCheckingForStartSponsors();
             }
 
             // Make sure it doesn't get double called with the play event
             if (
-                Math.abs(lastCheckVideoTime - video.currentTime) > 0.3 ||
-                (lastCheckVideoTime !== video.currentTime && Date.now() - lastCheckTime > 2000)
+                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
+                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
             ) {
-                lastCheckTime = Date.now();
-                lastCheckVideoTime = video.currentTime;
+                contentState.lastCheckTime = Date.now();
+                contentState.lastCheckVideoTime = video.currentTime;
 
                 startSponsorSchedule();
             }
@@ -1191,12 +1067,12 @@ function setupVideoListeners(video: HTMLVideoElement) {
         video.addEventListener("playing", playingListener);
 
         const seekingListener = () => {
-            lastKnownVideoTime.fromPause = false;
+            contentState.lastKnownVideoTime.fromPause = false;
 
             if (!video.paused) {
                 // Reset lastCheckVideoTime
-                lastCheckTime = Date.now();
-                lastCheckVideoTime = video.currentTime;
+                contentState.lastCheckTime = Date.now();
+                contentState.lastCheckVideoTime = video.currentTime;
 
                 updateVirtualTime();
                 clearWaitingTime();
@@ -1220,19 +1096,19 @@ function setupVideoListeners(video: HTMLVideoElement) {
 
         const stoppedPlayback = () => {
             // Reset lastCheckVideoTime
-            lastCheckVideoTime = -1;
-            lastCheckTime = 0;
+            contentState.lastCheckVideoTime = -1;
+            contentState.lastCheckTime = 0;
 
             if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
 
-            lastKnownVideoTime.videoTime = null;
-            lastKnownVideoTime.preciseTime = null;
+            contentState.lastKnownVideoTime.videoTime = null;
+            contentState.lastKnownVideoTime.preciseTime = null;
             updateWaitingTime();
 
             cancelSponsorSchedule();
         };
         const pauseListener = () => {
-            lastKnownVideoTime.fromPause = true;
+            contentState.lastKnownVideoTime.fromPause = true;
 
             stoppedPlayback();
         };
@@ -1266,19 +1142,19 @@ function setupVideoListeners(video: HTMLVideoElement) {
 }
 
 function updateVirtualTime() {
-    if (currentVirtualTimeInterval) clearInterval(currentVirtualTimeInterval);
+    if (contentState.currentVirtualTimeInterval) clearInterval(contentState.currentVirtualTimeInterval);
 
-    lastKnownVideoTime.videoTime = getVideo().currentTime;
-    lastKnownVideoTime.preciseTime = performance.now();
+    contentState.lastKnownVideoTime.videoTime = getVideo().currentTime;
+    contentState.lastKnownVideoTime.preciseTime = performance.now();
 
     // If on Firefox, wait for the second time change (time remains fixed for many "frames" for privacy reasons)
     if (isFirefoxOrSafari()) {
         let count = 0;
         let rawCount = 0;
-        let lastTime = lastKnownVideoTime.videoTime;
+        let lastTime = contentState.lastKnownVideoTime.videoTime;
         let lastPerformanceTime = performance.now();
 
-        currentVirtualTimeInterval = setInterval(() => {
+        contentState.currentVirtualTimeInterval = setInterval(() => {
             const frameTime = performance.now() - lastPerformanceTime;
             if (lastTime !== getVideo().currentTime) {
                 rawCount++;
@@ -1292,15 +1168,15 @@ function updateVirtualTime() {
 
             if (count > 1) {
                 const delay =
-                    lastKnownVideoTime.fromPause && lastKnownVideoTime.approximateDelay
-                        ? lastKnownVideoTime.approximateDelay
+                    contentState.lastKnownVideoTime.fromPause && contentState.lastKnownVideoTime.approximateDelay
+                        ? contentState.lastKnownVideoTime.approximateDelay
                         : 0;
 
-                lastKnownVideoTime.videoTime = getVideo().currentTime + delay;
-                lastKnownVideoTime.preciseTime = performance.now();
+                contentState.lastKnownVideoTime.videoTime = getVideo().currentTime + delay;
+                contentState.lastKnownVideoTime.preciseTime = performance.now();
 
-                clearInterval(currentVirtualTimeInterval);
-                currentVirtualTimeInterval = null;
+                clearInterval(contentState.currentVirtualTimeInterval);
+                contentState.currentVirtualTimeInterval = null;
             }
 
             lastPerformanceTime = performance.now();
@@ -1309,16 +1185,16 @@ function updateVirtualTime() {
 }
 
 function updateWaitingTime(): void {
-    lastTimeFromWaitingEvent = getVideo().currentTime;
+    contentState.lastTimeFromWaitingEvent = getVideo().currentTime;
 }
 
 function clearWaitingTime(): void {
-    lastTimeFromWaitingEvent = null;
+    contentState.lastTimeFromWaitingEvent = null;
 }
 
 function setupSkipButtonControlBar() {
-    if (!skipButtonControlBar) {
-        skipButtonControlBar = new SkipButtonControlBar({
+    if (!contentState.skipButtonControlBar) {
+        contentState.skipButtonControlBar = new SkipButtonControlBar({
             skip: (segment) =>
                 skipToTime({
                     v: getVideo(),
@@ -1331,20 +1207,20 @@ function setupSkipButtonControlBar() {
         });
     }
 
-    skipButtonControlBar.attachToPage();
+    contentState.skipButtonControlBar.attachToPage();
 }
 
 function setupCategoryPill() {
-    if (!categoryPill) {
-        categoryPill = new CategoryPill();
+    if (!contentState.categoryPill) {
+        contentState.categoryPill = new CategoryPill();
     }
 
-    categoryPill.attachToPage(voteAsync);
+    contentState.categoryPill.attachToPage(voteAsync);
 }
 
 function setupDescriptionPill() {
-    if (!descriptionPill) {
-        descriptionPill = new DescriptionPortPill(
+    if (!contentState.descriptionPill) {
+        contentState.descriptionPill = new DescriptionPortPill(
             getPortVideo,
             submitPortVideo,
             portVideoVote,
@@ -1352,20 +1228,20 @@ function setupDescriptionPill() {
             sponsorsLookup
         );
     }
-    descriptionPill.setupDescription(getVideoID());
+    contentState.descriptionPill.setupDescription(getVideoID());
 }
 
 async function updatePortVideoElements(newPortVideo: PortVideo) {
-    portVideo = newPortVideo;
+    contentState.portVideo = newPortVideo;
     // notify description pill
-    waitFor(() => descriptionPill).then(() => descriptionPill.setPortVideoData(newPortVideo));
+    waitFor(() => contentState.descriptionPill).then(() => contentState.descriptionPill.setPortVideoData(newPortVideo));
 
     // notify popup of port video changes
     chrome.runtime.sendMessage({
         message: "infoUpdated",
-        found: sponsorDataFound,
-        status: lastResponseStatus,
-        sponsorTimes: sponsorTimes,
+        found: contentState.sponsorDataFound,
+        status: contentState.lastResponseStatus,
+        sponsorTimes: contentState.sponsorTimes,
         portVideo: newPortVideo,
         time: getVideo()?.currentTime ?? 0,
     });
@@ -1373,16 +1249,16 @@ async function updatePortVideoElements(newPortVideo: PortVideo) {
 
 async function getPortVideo(videoId: NewVideoID, bypassCache = false) {
     const newPortVideo = await getPortVideoByHash(videoId, { bypassCache });
-    if (newPortVideo?.UUID === portVideo?.UUID) return;
-    portVideo = newPortVideo;
+    if (newPortVideo?.UUID === contentState.portVideo?.UUID) return;
+    contentState.portVideo = newPortVideo;
 
-    updatePortVideoElements(portVideo);
+    updatePortVideoElements(contentState.portVideo);
 }
 
 async function submitPortVideo(ytbID: YTID): Promise<PortVideo> {
     const newPortVideo = await postPortVideo(getVideoID(), ytbID, getVideo()?.duration);
-    portVideo = newPortVideo;
-    updatePortVideoElements(portVideo);
+    contentState.portVideo = newPortVideo;
+    updatePortVideoElements(contentState.portVideo);
     sponsorsLookup(true, true, true);
     return newPortVideo;
 }
@@ -1407,15 +1283,15 @@ async function sponsorsLookup(keepOldSubmissions = true, ignoreServerCache = fal
         console.error("[SponsorBlock] Attempted to fetch segments with a null/undefined videoID.");
         return;
     }
-    if (lookupWaiting) return;
+    if (contentState.lookupWaiting) return;
 
     if (!getVideo()) {
         //there is still no video here
         await waitForVideo();
 
-        lookupWaiting = true;
+        contentState.lookupWaiting = true;
         setTimeout(() => {
-            lookupWaiting = false;
+            contentState.lookupWaiting = false;
             sponsorsLookup(keepOldSubmissions, ignoreServerCache, forceUpdatePreviewBar);
         }, 100);
         return;
@@ -1432,7 +1308,7 @@ async function sponsorsLookup(keepOldSubmissions = true, ignoreServerCache = fal
     if (videoID !== getVideoID()) return;
 
     // store last response status
-    lastResponseStatus = segmentResponse?.status;
+    contentState.lastResponseStatus = segmentResponse?.status;
 
     if (segmentResponse.status === 200) {
         // filter and refresh cid
@@ -1450,24 +1326,24 @@ async function sponsorsLookup(keepOldSubmissions = true, ignoreServerCache = fal
         }
 
         if (receivedSegments && receivedSegments.length) {
-            sponsorDataFound = true;
+            contentState.sponsorDataFound = true;
 
             // Check if any old submissions should be kept
-            if (sponsorTimes !== null && keepOldSubmissions) {
-                for (let i = 0; i < sponsorTimes.length; i++) {
-                    if (sponsorTimes[i].source === SponsorSourceType.Local) {
+            if (contentState.sponsorTimes !== null && keepOldSubmissions) {
+                for (let i = 0; i < contentState.sponsorTimes.length; i++) {
+                    if (contentState.sponsorTimes[i].source === SponsorSourceType.Local) {
                         // This is a user submission, keep it
-                        receivedSegments.push(sponsorTimes[i]);
+                        receivedSegments.push(contentState.sponsorTimes[i]);
                     }
                 }
             }
 
-            const oldSegments = sponsorTimes || [];
-            sponsorTimes = receivedSegments;
+            const oldSegments = contentState.sponsorTimes || [];
+            contentState.sponsorTimes = receivedSegments;
 
             // Hide all submissions smaller than the minimum duration
             if (Config.config.minDuration !== 0) {
-                for (const segment of sponsorTimes) {
+                for (const segment of contentState.sponsorTimes) {
                     const duration = segment.segment[1] - segment.segment[0];
                     if (duration > 0 && duration < Config.config.minDuration) {
                         segment.hidden = SponsorHideType.MinimumDuration;
@@ -1477,7 +1353,7 @@ async function sponsorsLookup(keepOldSubmissions = true, ignoreServerCache = fal
 
             if (keepOldSubmissions) {
                 for (const segment of oldSegments) {
-                    const otherSegment = sponsorTimes.find((other) => segment.UUID === other.UUID);
+                    const otherSegment = contentState.sponsorTimes.find((other) => segment.UUID === other.UUID);
                     if (otherSegment) {
                         // If they downvoted it, or changed the category, keep it
                         otherSegment.hidden = segment.hidden;
@@ -1489,7 +1365,7 @@ async function sponsorsLookup(keepOldSubmissions = true, ignoreServerCache = fal
             // See if some segments should be hidden
             const downvotedData = Config.local.downvotedSegments[hashPrefix];
             if (downvotedData) {
-                for (const segment of sponsorTimes) {
+                for (const segment of contentState.sponsorTimes) {
                     const hashedUUID = await getHash(segment.UUID, 1);
                     const segmentDownvoteData = downvotedData.segments.find((downvote) => downvote.uuid === hashedUUID);
                     if (segmentDownvoteData) {
@@ -1504,8 +1380,8 @@ async function sponsorsLookup(keepOldSubmissions = true, ignoreServerCache = fal
             //leave the type blank for now until categories are added
             if (
                 forceUpdatePreviewBar ||
-                lastPreviewBarUpdate == getVideoID() ||
-                (lastPreviewBarUpdate == null && !isNaN(getVideo().duration))
+                contentState.lastPreviewBarUpdate == getVideoID() ||
+                (contentState.lastPreviewBarUpdate == null && !isNaN(getVideo().duration))
             ) {
                 //set it now
                 //otherwise the listener can handle it
@@ -1517,10 +1393,10 @@ async function sponsorsLookup(keepOldSubmissions = true, ignoreServerCache = fal
     // notify popup of segment changes
     chrome.runtime.sendMessage({
         message: "infoUpdated",
-        found: sponsorDataFound,
-        status: lastResponseStatus,
-        sponsorTimes: sponsorTimes,
-        portVideo: portVideo,
+        found: contentState.sponsorDataFound,
+        status: contentState.lastResponseStatus,
+        sponsorTimes: contentState.sponsorTimes,
+        portVideo: contentState.portVideo,
         time: getVideo()?.currentTime ?? 0,
     });
 
@@ -1539,7 +1415,7 @@ async function lockedCategoriesLookup(): Promise<void> {
                 (lockInfo) => lockInfo.videoID === getVideoID()
             )[0]?.categories;
             if (Array.isArray(categoriesResponse)) {
-                lockedCategories = categoriesResponse;
+                contentState.lockedCategories = categoriesResponse;
             }
         } catch (e) { } //eslint-disable-line no-empty
     }
@@ -1553,11 +1429,11 @@ async function lockedCategoriesLookup(): Promise<void> {
  */
 function startSkipScheduleCheckingForStartSponsors() {
     // switchingVideos is ignored in Safari due to event fire order. See #1142
-    if ((!switchingVideos || isSafari()) && sponsorTimes) {
+    if ((!contentState.switchingVideos || isSafari()) && contentState.sponsorTimes) {
         // See if there are any starting sponsors
         let startingSegmentTime = getStartTimeFromUrl(document.URL) || -1;
         let found = false;
-        for (const time of sponsorTimes) {
+        for (const time of contentState.sponsorTimes) {
             if (
                 time.segment[0] <= getVideo().currentTime &&
                 time.segment[0] > startingSegmentTime &&
@@ -1570,7 +1446,7 @@ function startSkipScheduleCheckingForStartSponsors() {
             }
         }
         if (!found) {
-            for (const time of sponsorTimesSubmitting) {
+            for (const time of contentState.sponsorTimesSubmitting) {
                 if (
                     time.segment[0] <= getVideo().currentTime &&
                     time.segment[0] > startingSegmentTime &&
@@ -1585,7 +1461,7 @@ function startSkipScheduleCheckingForStartSponsors() {
         }
 
         // For highlight category
-        const poiSegments = sponsorTimes
+        const poiSegments = contentState.sponsorTimes
             .filter(
                 (time) =>
                     time.segment[1] > getVideo().currentTime &&
@@ -1607,10 +1483,10 @@ function startSkipScheduleCheckingForStartSponsors() {
             }
         }
 
-        const fullVideoSegment = sponsorTimes.filter((time) => time.actionType === ActionType.Full)[0];
+        const fullVideoSegment = contentState.sponsorTimes.filter((time) => time.actionType === ActionType.Full)[0];
         if (fullVideoSegment) {
-            waitFor(() => categoryPill).then(() => {
-                categoryPill?.setSegment(fullVideoSegment);
+            waitFor(() => contentState.categoryPill).then(() => {
+                contentState.categoryPill?.setSegment(fullVideoSegment);
             });
         }
 
@@ -1623,19 +1499,19 @@ function startSkipScheduleCheckingForStartSponsors() {
 }
 
 function selectSegment(UUID: SegmentUUID): void {
-    selectedSegment = UUID;
+    contentState.selectedSegment = UUID;
     updatePreviewBar();
 }
 
 function updatePreviewBar(): void {
-    if (previewBar === null) return;
+    if (contentState.previewBar === null) return;
     if (getVideo() === null) return;
 
     const hashParams = getHashParams();
     const requiredSegment = (hashParams?.requiredSegment as SegmentUUID) || undefined;
     const previewBarSegments: PreviewBarSegment[] = [];
-    if (sponsorTimes) {
-        sponsorTimes.forEach((segment) => {
+    if (contentState.sponsorTimes) {
+        contentState.sponsorTimes.forEach((segment) => {
             if (segment.hidden !== SponsorHideType.Visible) return;
 
             previewBarSegments.push({
@@ -1647,12 +1523,12 @@ function updatePreviewBar(): void {
                 source: segment.source,
                 requiredSegment:
                     requiredSegment && (segment.UUID === requiredSegment || segment.UUID?.startsWith(requiredSegment)),
-                selectedSegment: selectedSegment && segment.UUID === selectedSegment,
+                selectedSegment: contentState.selectedSegment && segment.UUID === contentState.selectedSegment,
             });
         });
     }
 
-    sponsorTimesSubmitting.forEach((segment) => {
+    contentState.sponsorTimesSubmitting.forEach((segment) => {
         previewBarSegments.push({
             segment: segment.segment as [number, number],
             category: segment.category,
@@ -1663,7 +1539,7 @@ function updatePreviewBar(): void {
         });
     });
 
-    previewBar.set(
+    contentState.previewBar.set(
         previewBarSegments.filter((segment) => segment.actionType !== ActionType.Full),
         getVideo()?.duration
     );
@@ -1682,7 +1558,7 @@ function updatePreviewBar(): void {
     }
 
     // Update last video id
-    lastPreviewBarUpdate = getVideoID();
+    contentState.lastPreviewBarUpdate = getVideoID();
 }
 
 //checks if this channel is whitelisted, should be done only after the channelID has been loaded
@@ -1695,11 +1571,11 @@ async function channelIDChange(channelIDInfo: ChannelIDInfo) {
         channelIDInfo.status === ChannelIDStatus.Found &&
         whitelistedChannels.some(ch => ch.id === channelIDInfo.id)
     ) {
-        channelWhitelisted = true;
+        contentState.channelWhitelisted = true;
     }
 
     // check if the start of segments were missed
-    if (Config.config.forceChannelCheck && sponsorTimes?.length > 0) startSkipScheduleCheckingForStartSponsors();
+    if (Config.config.forceChannelCheck && contentState.sponsorTimes?.length > 0) startSkipScheduleCheckingForStartSponsors();
 }
 
 function videoElementChange(newVideo: boolean, video: HTMLVideoElement): void {
@@ -1722,9 +1598,9 @@ function videoElementChange(newVideo: boolean, video: HTMLVideoElement): void {
 }
 
 function checkPreviewbarState(): void {
-    if (previewBar && !utils.findReferenceNode()?.contains(previewBar.container)) {
-        previewBar.remove();
-        previewBar = null;
+    if (contentState.previewBar && !utils.findReferenceNode()?.contains(contentState.previewBar.container)) {
+        contentState.previewBar.remove();
+        contentState.previewBar = null;
         removeDurationAfterSkip();
     }
 
@@ -1755,12 +1631,12 @@ function getNextSkipIndex(
     };
 
     const { includedTimes: submittedArray, scheduledTimes: sponsorStartTimes } = getStartTimes(
-        sponsorTimes,
+        contentState.sponsorTimes,
         includeIntersectingSegments,
         includeNonIntersectingSegments
     );
     const { scheduledTimes: sponsorStartTimesAfterCurrentTime } = getStartTimes(
-        sponsorTimes,
+        contentState.sponsorTimes,
         includeIntersectingSegments,
         includeNonIntersectingSegments,
         currentTime,
@@ -1789,12 +1665,12 @@ function getNextSkipIndex(
     const endTimeIndex = getLatestEndTimeIndex(submittedArray, minSponsorTimeIndex);
 
     const { includedTimes: unsubmittedArray, scheduledTimes: unsubmittedSponsorStartTimes } = getStartTimes(
-        sponsorTimesSubmitting,
+        contentState.sponsorTimesSubmitting,
         includeIntersectingSegments,
         includeNonIntersectingSegments
     );
     const { scheduledTimes: unsubmittedSponsorStartTimesAfterCurrentTime } = getStartTimes(
-        sponsorTimesSubmitting,
+        contentState.sponsorTimesSubmitting,
         includeIntersectingSegments,
         includeNonIntersectingSegments,
         currentTime,
@@ -1942,7 +1818,7 @@ function getStartTimes(
  * @param time
  */
 function previewTime(time: number, unpause = true) {
-    previewedSegment = true;
+    contentState.previewedSegment = true;
     getVideo().currentTime = time;
 
     // Unpause the video if needed
@@ -1954,9 +1830,9 @@ function previewTime(time: number, unpause = true) {
 //send telemetry and count skip
 function sendTelemetryAndCount(skippingSegments: SponsorTime[], secondsSkipped: number, fullSkip: boolean) {
     for (const segment of skippingSegments) {
-        if (!previewedSegment && sponsorTimesSubmitting.some((s) => s.segment === segment.segment)) {
+        if (!contentState.previewedSegment && contentState.sponsorTimesSubmitting.some((s) => s.segment === segment.segment)) {
             // Count that as a previewed segment
-            previewedSegment = true;
+            contentState.previewedSegment = true;
         }
     }
 
@@ -1968,9 +1844,9 @@ function sendTelemetryAndCount(skippingSegments: SponsorTime[], secondsSkipped: 
 
     let counted = false;
     for (const segment of skippingSegments) {
-        const index = sponsorTimes?.findIndex((s) => s.segment === segment.segment);
-        if (index !== -1 && !sponsorSkipped[index]) {
-            sponsorSkipped[index] = true;
+        const index = contentState.sponsorTimes?.findIndex((s) => s.segment === segment.segment);
+        if (index !== -1 && !contentState.sponsorSkipped[index]) {
+            contentState.sponsorSkipped[index] = true;
             if (!counted) {
                 Config.config.minutesSaved = Config.config.minutesSaved + secondsSkipped / 60;
                 Config.config.skipCount = Config.config.skipCount + 1;
@@ -1995,7 +1871,7 @@ function skipToTime({ v, skipTime, skippingSegments, openNotice, forceAutoSkip, 
         autoSkip = forceAutoSkip || shouldAutoSkip(skippingSegments[0]);
     }
 
-    const isSubmittingSegment = sponsorTimesSubmitting.some((time) => time.segment === skippingSegments[0].segment);
+    const isSubmittingSegment = contentState.sponsorTimesSubmitting.some((time) => time.segment === skippingSegments[0].segment);
 
     if ((autoSkip || isSubmittingSegment) && v.currentTime !== skipTime[1]) {
         switch (skippingSegments[0].actionType) {
@@ -2024,7 +1900,7 @@ function skipToTime({ v, skipTime, skippingSegments, openNotice, forceAutoSkip, 
                     if (inMuteSegment(skipTime[1], true)) {
                         // Make sure not to mute if skipping into a mute segment
                         v.muted = true;
-                        videoMuted = true;
+                        contentState.videoMuted = true;
                     }
 
                     v.currentTime = skipTime[1];
@@ -2035,7 +1911,7 @@ function skipToTime({ v, skipTime, skippingSegments, openNotice, forceAutoSkip, 
             case ActionType.Mute: {
                 if (!v.muted) {
                     v.muted = true;
-                    videoMuted = true;
+                    contentState.videoMuted = true;
                 }
                 break;
             }
@@ -2057,12 +1933,12 @@ function skipToTime({ v, skipTime, skippingSegments, openNotice, forceAutoSkip, 
     }
 
     if (!autoSkip && skippingSegments.length === 1 && skippingSegments[0].actionType === ActionType.Poi) {
-        waitFor(() => skipButtonControlBar).then(() => {
-            skipButtonControlBar.enable(skippingSegments[0]);
-            if (Config.config.skipKeybind == null) skipButtonControlBar.setShowKeybindHint(false);
+        waitFor(() => contentState.skipButtonControlBar).then(() => {
+            contentState.skipButtonControlBar.enable(skippingSegments[0]);
+            if (Config.config.skipKeybind == null) contentState.skipButtonControlBar.setShowKeybindHint(false);
 
-            activeSkipKeybindElement?.setShowKeybindHint(false);
-            activeSkipKeybindElement = skipButtonControlBar;
+            contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
+            contentState.activeSkipKeybindElement = contentState.skipButtonControlBar;
         });
     } else {
         if (openNotice) {
@@ -2070,8 +1946,8 @@ function skipToTime({ v, skipTime, skippingSegments, openNotice, forceAutoSkip, 
             if (!Config.config.dontShowNotice || !autoSkip) {
                 createSkipNotice(skippingSegments, autoSkip, unskipTime, false);
             } else if (autoSkip) {
-                activeSkipKeybindElement?.setShowKeybindHint(false);
-                activeSkipKeybindElement = {
+                contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
+                contentState.activeSkipKeybindElement = {
                     setShowKeybindHint: () => { },
                     toggleSkip: () => {
                         createSkipNotice(skippingSegments, autoSkip, unskipTime, true);
@@ -2093,7 +1969,7 @@ function createSkipNotice(
     unskipTime: number,
     startReskip: boolean
 ) {
-    for (const skipNotice of skipNotices) {
+    for (const skipNotice of contentState.skipNotices) {
         if (
             skippingSegments.length === skipNotice.segments.length &&
             skippingSegments.every((segment) => skipNotice.segments.some((s) => s.UUID === segment.UUID))
@@ -2103,24 +1979,24 @@ function createSkipNotice(
         }
     }
 
-    const advanceSkipNoticeShow = !!advanceSkipNotices;
+    const advanceSkipNoticeShow = !!contentState.advanceSkipNotices;
     const newSkipNotice = new SkipNotice(
         skippingSegments,
         autoSkip,
         skipNoticeContentContainer,
         () => {
-            advanceSkipNotices?.close();
-            advanceSkipNotices = null;
+            contentState.advanceSkipNotices?.close();
+            contentState.advanceSkipNotices = null;
         },
         unskipTime,
         startReskip,
         advanceSkipNoticeShow
     );
     if (Config.config.skipKeybind == null) newSkipNotice.setShowKeybindHint(false);
-    skipNotices.push(newSkipNotice);
+    contentState.skipNotices.push(newSkipNotice);
 
-    activeSkipKeybindElement?.setShowKeybindHint(false);
-    activeSkipKeybindElement = newSkipNotice;
+    contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
+    contentState.activeSkipKeybindElement = newSkipNotice;
 }
 
 function createAdvanceSkipNotice(
@@ -2129,28 +2005,28 @@ function createAdvanceSkipNotice(
     autoSkip: boolean,
     startReskip: boolean
 ) {
-    if (advanceSkipNotices && !advanceSkipNotices.closed && advanceSkipNotices.sameNotice(skippingSegments)) {
+    if (contentState.advanceSkipNotices && !contentState.advanceSkipNotices.closed && contentState.advanceSkipNotices.sameNotice(skippingSegments)) {
         return;
     }
 
-    advanceSkipNotices?.close();
-    advanceSkipNotices = new advanceSkipNotice(
+    contentState.advanceSkipNotices?.close();
+    contentState.advanceSkipNotices = new advanceSkipNotice(
         skippingSegments,
         skipNoticeContentContainer,
         unskipTime,
         autoSkip,
         startReskip
     );
-    if (Config.config.skipKeybind == null) advanceSkipNotices.setShowKeybindHint(false);
+    if (Config.config.skipKeybind == null) contentState.advanceSkipNotices.setShowKeybindHint(false);
 
-    activeSkipKeybindElement?.setShowKeybindHint(false);
-    activeSkipKeybindElement = advanceSkipNotices;
+    contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
+    contentState.activeSkipKeybindElement = contentState.advanceSkipNotices;
 }
 
 function unskipSponsorTime(segment: SponsorTime, unskipTime: number = null, forceSeek = false) {
     if (segment.actionType === ActionType.Mute) {
         getVideo().muted = false;
-        videoMuted = false;
+        contentState.videoMuted = false;
     }
 
     if (forceSeek || segment.actionType === ActionType.Skip) {
@@ -2162,7 +2038,7 @@ function unskipSponsorTime(segment: SponsorTime, unskipTime: number = null, forc
 function reskipSponsorTime(segment: SponsorTime, forceSeek = false) {
     if (segment.actionType === ActionType.Mute && !forceSeek) {
         getVideo().muted = true;
-        videoMuted = true;
+        contentState.videoMuted = true;
     } else {
         const skippedTime = Math.max(segment.segment[1] - getVideo().currentTime, 0);
         const segmentDuration = segment.segment[1] - segment.segment[0];
@@ -2182,7 +2058,7 @@ function shouldAutoSkip(segment: SponsorTime): boolean {
     // Check if manual skip on full video is disabled or there is no full video segment for this category
     if (
         Config.config.manualSkipOnFullVideo &&
-        sponsorTimes?.some((s) => s.category === segment.category && s.actionType === ActionType.Full)
+        contentState.sponsorTimes?.some((s) => s.category === segment.category && s.actionType === ActionType.Full)
     ) {
         return false;
     }
@@ -2196,13 +2072,13 @@ function shouldAutoSkip(segment: SponsorTime): boolean {
     // Check if auto skip on music videos is enabled and there's a "music_offtopic" segment, and the current segment is of type Skip
     else if (
         Config.config.autoSkipOnMusicVideos &&
-        sponsorTimes?.some((s) => s.category === "music_offtopic") &&
+        contentState.sponsorTimes?.some((s) => s.category === "music_offtopic") &&
         segment.actionType === ActionType.Skip
     ) {
         return true;
     }
     // Check if this segment is in the submitting segments
-    else if (sponsorTimesSubmitting.some((s) => s.segment === segment.segment)) {
+    else if (contentState.sponsorTimesSubmitting.some((s) => s.segment === segment.segment)) {
         return true;
     }
 
@@ -2216,7 +2092,7 @@ function shouldSkip(segment: SponsorTime): boolean {
             segment.source !== SponsorSourceType.YouTube &&
             utils.getCategorySelection(segment.category)?.option !== CategorySkipOption.ShowOverlay) ||
         (Config.config.autoSkipOnMusicVideos &&
-            sponsorTimes?.some((s) => s.category === "music_offtopic") &&
+            contentState.sponsorTimes?.some((s) => s.category === "music_offtopic") &&
             segment.actionType === ActionType.Skip)
     );
 }
@@ -2226,7 +2102,7 @@ async function updateVisibilityOfPlayerControlsButton(): Promise<void> {
     // Not on a proper video yet
     if (!getVideoID()) return;
 
-    playerButtons = await playerButton.createButtons();
+    contentState.playerButtons = await playerButton.createButtons();
 
     updateSegmentSubmitting();
 }
@@ -2235,7 +2111,7 @@ async function updateVisibilityOfPlayerControlsButton(): Promise<void> {
 function updateSegmentSubmitting(): void {
     // Don't try to update the buttons if we aren't on a Bilibili video page
     if (!getVideoID()) return;
-    playerButton.updateSegmentSubmitting(sponsorTimesSubmitting);
+    playerButton.updateSegmentSubmitting(contentState.sponsorTimesSubmitting);
 }
 
 /**
@@ -2258,7 +2134,7 @@ function getRealCurrentTime(): number {
 function startOrEndTimingNewSegment() {
     const roundedTime = Math.round((getRealCurrentTime() + Number.EPSILON) * 1000) / 1000;
     if (!isSegmentCreationInProgress()) {
-        sponsorTimesSubmitting.push({
+        contentState.sponsorTimesSubmitting.push({
             cid: getCid(),
             segment: [roundedTime],
             UUID: generateUserID() as SegmentUUID,
@@ -2277,7 +2153,7 @@ function startOrEndTimingNewSegment() {
     }
 
     // Save the newly created segment
-    Config.local.unsubmittedSegments[getVideoID()] = sponsorTimesSubmitting;
+    Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
     Config.forceLocalUpdate("unsubmittedSegments");
 
     // Make sure they know if someone has already submitted something it while they were watching
@@ -2287,19 +2163,19 @@ function startOrEndTimingNewSegment() {
     updateSponsorTimesSubmitting(false);
 
     if (
-        lastResponseStatus !== 200 &&
-        lastResponseStatus !== 404 &&
-        !shownSegmentFailedToFetchWarning &&
+        contentState.lastResponseStatus !== 200 &&
+        contentState.lastResponseStatus !== 404 &&
+        !contentState.shownSegmentFailedToFetchWarning &&
         Config.config.showSegmentFailedToFetchWarning
     ) {
         showMessage(chrome.i18n.getMessage("segmentFetchFailureWarning"), "warning");
 
-        shownSegmentFailedToFetchWarning = true;
+        contentState.shownSegmentFailedToFetchWarning = true;
     }
 }
 
 function getIncompleteSegment(): SponsorTime {
-    return sponsorTimesSubmitting[sponsorTimesSubmitting.length - 1];
+    return contentState.sponsorTimesSubmitting[contentState.sponsorTimesSubmitting.length - 1];
 }
 
 /** Is the latest submitting segment incomplete */
@@ -2310,14 +2186,14 @@ function isSegmentCreationInProgress(): boolean {
 
 function cancelCreatingSegment() {
     if (isSegmentCreationInProgress()) {
-        if (sponsorTimesSubmitting.length > 1) {
+        if (contentState.sponsorTimesSubmitting.length > 1) {
             // If there's more than one segment: remove last
-            sponsorTimesSubmitting.pop();
-            Config.local.unsubmittedSegments[getVideoID()] = sponsorTimesSubmitting;
+            contentState.sponsorTimesSubmitting.pop();
+            Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
         } else {
             // Otherwise delete the video entry & close submission menu
             resetSponsorSubmissionNotice();
-            sponsorTimesSubmitting = [];
+            contentState.sponsorTimesSubmitting = [];
             delete Config.local.unsubmittedSegments[getVideoID()];
         }
         Config.forceLocalUpdate("unsubmittedSegments");
@@ -2332,10 +2208,10 @@ function updateSponsorTimesSubmitting(getFromConfig = true) {
 
     //see if this data should be saved in the sponsorTimesSubmitting variable
     if (getFromConfig && segmentTimes != undefined) {
-        sponsorTimesSubmitting = [];
+        contentState.sponsorTimesSubmitting = [];
 
         for (const segmentTime of segmentTimes) {
-            sponsorTimesSubmitting.push({
+            contentState.sponsorTimesSubmitting.push({
                 cid: getCid(),
                 segment: segmentTime.segment,
                 UUID: segmentTime.UUID,
@@ -2345,9 +2221,9 @@ function updateSponsorTimesSubmitting(getFromConfig = true) {
             });
         }
 
-        if (sponsorTimesSubmitting.length > 0) {
+        if (contentState.sponsorTimesSubmitting.length > 0) {
             // Assume they already previewed a segment
-            previewedSegment = true;
+            contentState.previewedSegment = true;
         }
     }
 
@@ -2356,8 +2232,8 @@ function updateSponsorTimesSubmitting(getFromConfig = true) {
     // Restart skipping schedule
     if (getVideo() !== null) startSponsorSchedule();
 
-    if (submissionNotice !== null) {
-        submissionNotice.update();
+    if (contentState.submissionNotice !== null) {
+        contentState.submissionNotice.update();
     }
 
     checkForPreloadedSegment();
@@ -2369,7 +2245,7 @@ function openInfoMenu() {
         return;
     }
 
-    popupInitialised = false;
+    contentState.popupInitialised = false;
 
     const popup = document.createElement("div");
     popup.id = "sponsorBlockPopupContainer";
@@ -2425,7 +2301,7 @@ function clearSponsorTimes() {
         Config.forceLocalUpdate("unsubmittedSegments");
 
         //clear sponsor times submitting
-        sponsorTimesSubmitting = [];
+        contentState.sponsorTimesSubmitting = [];
 
         updatePreviewBar();
         updateSegmentSubmitting();
@@ -2451,7 +2327,7 @@ async function vote(
         if (skipNotice != null) {
             if (response.successType == 1 || (response.successType == -1 && response.statusCode == 429)) {
                 //success (treat rate limits as a success)
-                skipNotice.afterVote.bind(skipNotice)(utils.getSponsorTimeFromUUID(sponsorTimes, UUID), type, category);
+                skipNotice.afterVote.bind(skipNotice)(utils.getSponsorTimeFromUUID(contentState.sponsorTimes, UUID), type, category);
             } else if (response.successType == -1) {
                 if (
                     response.statusCode === 403 &&
@@ -2473,25 +2349,25 @@ async function vote(
 }
 
 async function voteAsync(type: number, UUID: SegmentUUID, category?: Category): Promise<VoteResponse | undefined> {
-    const sponsorIndex = utils.getSponsorIndexFromUUID(sponsorTimes, UUID);
+    const sponsorIndex = utils.getSponsorIndexFromUUID(contentState.sponsorTimes, UUID);
 
     // Don't vote for preview sponsors
-    if (sponsorIndex == -1 || sponsorTimes[sponsorIndex].source !== SponsorSourceType.Server)
+    if (sponsorIndex == -1 || contentState.sponsorTimes[sponsorIndex].source !== SponsorSourceType.Server)
         return Promise.resolve(undefined);
 
     // See if the local time saved count and skip count should be saved
-    if ((type === 0 && sponsorSkipped[sponsorIndex]) || (type === 1 && !sponsorSkipped[sponsorIndex])) {
+    if ((type === 0 && contentState.sponsorSkipped[sponsorIndex]) || (type === 1 && !contentState.sponsorSkipped[sponsorIndex])) {
         let factor = 1;
         if (type == 0) {
             factor = -1;
 
-            sponsorSkipped[sponsorIndex] = false;
+            contentState.sponsorSkipped[sponsorIndex] = false;
         }
 
         // Count this as a skip
         Config.config.minutesSaved =
             Config.config.minutesSaved +
-            (factor * (sponsorTimes[sponsorIndex].segment[1] - sponsorTimes[sponsorIndex].segment[0])) / 60;
+            (factor * (contentState.sponsorTimes[sponsorIndex].segment[1] - contentState.sponsorTimes[sponsorIndex].segment[0])) / 60;
 
         Config.config.skipCount = Config.config.skipCount + factor;
     }
@@ -2507,7 +2383,7 @@ async function voteAsync(type: number, UUID: SegmentUUID, category?: Category): 
             (response) => {
                 if (response.successType === 1) {
                     // Change the sponsor locally
-                    const segment = utils.getSponsorTimeFromUUID(sponsorTimes, UUID);
+                    const segment = utils.getSponsorTimeFromUUID(contentState.sponsorTimes, UUID);
                     if (segment) {
                         if (type === 0) {
                             segment.hidden = SponsorHideType.Downvoted;
@@ -2548,41 +2424,41 @@ function dontShowNoticeAgain() {
  * Helper method for the submission notice to clear itself when it closes
  */
 function resetSponsorSubmissionNotice(callRef = true) {
-    submissionNotice?.close(callRef);
-    submissionNotice = null;
+    contentState.submissionNotice?.close(callRef);
+    contentState.submissionNotice = null;
 }
 
 function closeSubmissionMenu() {
-    submissionNotice?.close();
-    submissionNotice = null;
+    contentState.submissionNotice?.close();
+    contentState.submissionNotice = null;
 }
 
 function openSubmissionMenu() {
-    if (submissionNotice !== null) {
+    if (contentState.submissionNotice !== null) {
         closeSubmissionMenu();
         return;
     }
 
-    if (sponsorTimesSubmitting !== undefined && sponsorTimesSubmitting.length > 0) {
-        submissionNotice = new SubmissionNotice(skipNoticeContentContainer, sendSubmitMessage);
+    if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0) {
+        contentState.submissionNotice = new SubmissionNotice(skipNoticeContentContainer, sendSubmitMessage);
         // Add key bind for jumpping to next frame, for easier sponsor time editting
         document.addEventListener("keydown", seekFrameByKeyPressListener);
     }
 }
 
 function previewRecentSegment() {
-    if (sponsorTimesSubmitting !== undefined && sponsorTimesSubmitting.length > 0) {
-        previewTime(sponsorTimesSubmitting[sponsorTimesSubmitting.length - 1].segment[0] - defaultPreviewTime);
+    if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0) {
+        previewTime(contentState.sponsorTimesSubmitting[contentState.sponsorTimesSubmitting.length - 1].segment[0] - defaultPreviewTime);
 
-        if (submissionNotice) {
-            submissionNotice.scrollToBottom();
+        if (contentState.submissionNotice) {
+            contentState.submissionNotice.scrollToBottom();
         }
     }
 }
 
 function submitSegments() {
-    if (sponsorTimesSubmitting !== undefined && sponsorTimesSubmitting.length > 0 && submissionNotice !== null) {
-        submissionNotice.submit();
+    if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0 && contentState.submissionNotice !== null) {
+        contentState.submissionNotice.submit();
     }
 }
 
@@ -2592,8 +2468,8 @@ async function sendSubmitMessage(): Promise<boolean> {
     // TODO: add checks for premiere videos
 
     if (
-        !previewedSegment &&
-        !sponsorTimesSubmitting.every(
+        !contentState.previewedSegment &&
+        !contentState.sponsorTimesSubmitting.every(
             (segment) =>
                 [ActionType.Full, ActionType.Poi].includes(segment.actionType) ||
                 segment.segment[1] >= getVideo()?.duration ||
@@ -2608,29 +2484,29 @@ async function sendSubmitMessage(): Promise<boolean> {
     }
 
     // Add loading animation
-    playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadIconSponsorBlocker.svg");
-    const stopAnimation = AnimationUtils.applyLoadingAnimation(playerButtons.submit.button, 1, () =>
+    contentState.playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadIconSponsorBlocker.svg");
+    const stopAnimation = AnimationUtils.applyLoadingAnimation(contentState.playerButtons.submit.button, 1, () =>
         updateSegmentSubmitting()
     );
 
     //check if a sponsor exceeds the duration of the video
-    for (let i = 0; i < sponsorTimesSubmitting.length; i++) {
-        if (sponsorTimesSubmitting[i].segment[1] > getVideo().duration) {
-            sponsorTimesSubmitting[i].segment[1] = getVideo().duration;
+    for (let i = 0; i < contentState.sponsorTimesSubmitting.length; i++) {
+        if (contentState.sponsorTimesSubmitting[i].segment[1] > getVideo().duration) {
+            contentState.sponsorTimesSubmitting[i].segment[1] = getVideo().duration;
         }
     }
 
     //update sponsorTimes
-    Config.local.unsubmittedSegments[getVideoID()] = sponsorTimesSubmitting;
+    Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
     Config.forceLocalUpdate("unsubmittedSegments");
 
     // Check to see if any of the submissions are below the minimum duration set
     if (Config.config.minDuration > 0) {
-        for (let i = 0; i < sponsorTimesSubmitting.length; i++) {
-            const duration = sponsorTimesSubmitting[i].segment[1] - sponsorTimesSubmitting[i].segment[0];
+        for (let i = 0; i < contentState.sponsorTimesSubmitting.length; i++) {
+            const duration = contentState.sponsorTimesSubmitting[i].segment[1] - contentState.sponsorTimesSubmitting[i].segment[0];
             if (duration > 0 && duration < Config.config.minDuration) {
                 const confirmShort =
-                    chrome.i18n.getMessage("shortCheck") + "\n\n" + getSegmentsMessage(sponsorTimesSubmitting);
+                    chrome.i18n.getMessage("shortCheck") + "\n\n" + getSegmentsMessage(contentState.sponsorTimesSubmitting);
 
                 if (!confirm(confirmShort)) return false;
             }
@@ -2641,7 +2517,7 @@ async function sendSubmitMessage(): Promise<boolean> {
         videoID: getBvID(),
         cid: getCid(),
         userID: Config.config.userID,
-        segments: sponsorTimesSubmitting,
+        segments: contentState.sponsorTimesSubmitting,
         videoDuration: getVideo()?.duration,
         userAgent: `${chrome.runtime.id}/v${chrome.runtime.getManifest().version}`,
     });
@@ -2653,7 +2529,7 @@ async function sendSubmitMessage(): Promise<boolean> {
         delete Config.local.unsubmittedSegments[getVideoID()];
         Config.forceLocalUpdate("unsubmittedSegments");
 
-        const newSegments = sponsorTimesSubmitting;
+        const newSegments = contentState.sponsorTimesSubmitting;
         try {
             const receivedNewSegments = JSON.parse(response.responseText);
             if (receivedNewSegments?.length === newSegments.length) {
@@ -2665,24 +2541,24 @@ async function sendSubmitMessage(): Promise<boolean> {
         } catch (e) { } // eslint-disable-line no-empty
 
         // Add submissions to current sponsors list
-        sponsorTimes = (sponsorTimes || []).concat(newSegments).sort((a, b) => a.segment[0] - b.segment[0]);
+        contentState.sponsorTimes = (contentState.sponsorTimes || []).concat(newSegments).sort((a, b) => a.segment[0] - b.segment[0]);
 
         // Increase contribution count
-        Config.config.sponsorTimesContributed = Config.config.sponsorTimesContributed + sponsorTimesSubmitting.length;
+        Config.config.sponsorTimesContributed = Config.config.sponsorTimesContributed + contentState.sponsorTimesSubmitting.length;
 
         // New count just used to see if a warning "Read The Guidelines!!" message needs to be shown
         // One per time submitting
         Config.config.submissionCountSinceCategories = Config.config.submissionCountSinceCategories + 1;
 
         // Empty the submitting times
-        sponsorTimesSubmitting = [];
+        contentState.sponsorTimesSubmitting = [];
 
         updatePreviewBar();
 
-        const fullVideoSegment = sponsorTimes.filter((time) => time.actionType === ActionType.Full)[0];
+        const fullVideoSegment = contentState.sponsorTimes.filter((time) => time.actionType === ActionType.Full)[0];
         if (fullVideoSegment) {
-            waitFor(() => categoryPill).then(() => {
-                categoryPill?.setSegment(fullVideoSegment);
+            waitFor(() => contentState.categoryPill).then(() => {
+                contentState.categoryPill?.setSegment(fullVideoSegment);
             });
             // refresh the video labels cache
             getVideoLabel(getVideoID(), true);
@@ -2691,8 +2567,8 @@ async function sendSubmitMessage(): Promise<boolean> {
         return true;
     } else {
         // Show that the upload failed
-        playerButtons.submit.button.style.animation = "unset";
-        playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadFailedIconSponsorBlocker.svg");
+        contentState.playerButtons.submit.button.style.animation = "unset";
+        contentState.playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadFailedIconSponsorBlocker.svg");
 
         if (
             response.status === 403 &&
@@ -2730,7 +2606,7 @@ function getSegmentsMessage(sponsorTimes: SponsorTime[]): string {
 }
 
 function updateActiveSegment(currentTime: number): void {
-    previewBar?.updateChapterText(sponsorTimes, sponsorTimesSubmitting, currentTime);
+    contentState.previewBar?.updateChapterText(contentState.sponsorTimes, contentState.sponsorTimesSubmitting, currentTime);
 
     chrome.runtime.sendMessage({
         message: "time",
@@ -2782,8 +2658,8 @@ function hotkeyListener(e: KeyboardEvent): void {
     const openSubmissionMenuKey = Config.config.submitKeybind;
 
     if (keybindEquals(key, skipKey)) {
-        if (activeSkipKeybindElement) {
-            activeSkipKeybindElement.toggleSkip.call(activeSkipKeybindElement);
+        if (contentState.activeSkipKeybindElement) {
+            contentState.activeSkipKeybindElement.toggleSkip.call(contentState.activeSkipKeybindElement);
 
             /*
              * 视频播放器全屏或网页全屏时，快捷键`Enter`会聚焦到弹幕输入框
@@ -2792,7 +2668,7 @@ function hotkeyListener(e: KeyboardEvent): void {
             if (key.key === 'Enter') {
                 const currentTime: number | null = document.querySelector<HTMLVideoElement>(".bpx-player-video-wrap video")?.currentTime ?? null;
                 if (currentTime) {
-                    const inSponsorRange = sponsorTimes.some(({ segment: [start, end] }) => start <= currentTime && end >= currentTime);
+                    const inSponsorRange = contentState.sponsorTimes.some(({ segment: [start, end] }) => start <= currentTime && end >= currentTime);
                     if (inSponsorRange) {
                         utils.biliBiliPlayerDanmakuInputBlur();
                     }
@@ -2803,14 +2679,14 @@ function hotkeyListener(e: KeyboardEvent): void {
 
         return;
     } else if (keybindEquals(key, skipToHighlightKey)) {
-        if (skipButtonControlBar) {
-            skipButtonControlBar.toggleSkip.call(skipButtonControlBar);
+        if (contentState.skipButtonControlBar) {
+            contentState.skipButtonControlBar.toggleSkip.call(contentState.skipButtonControlBar);
         }
 
         return;
     } else if (keybindEquals(key, closeSkipNoticeKey)) {
-        for (let i = 0; i < skipNotices.length; i++) {
-            skipNotices.pop().close();
+        for (let i = 0; i < contentState.skipNotices.length; i++) {
+            contentState.skipNotices.pop().close();
         }
 
         return;
@@ -2894,9 +2770,9 @@ function removeDurationAfterSkip() {
 }
 
 function checkForPreloadedSegment() {
-    if (loadedPreloadedSegment) return;
+    if (contentState.loadedPreloadedSegment) return;
 
-    loadedPreloadedSegment = true;
+    contentState.loadedPreloadedSegment = true;
     const hashParams = getHashParams();
 
     let pushed = false;
@@ -2905,11 +2781,11 @@ function checkForPreloadedSegment() {
         for (const segment of segments) {
             if (Array.isArray(segment.segment)) {
                 if (
-                    !sponsorTimesSubmitting.some(
+                    !contentState.sponsorTimesSubmitting.some(
                         (s) => s.segment[0] === segment.segment[0] && s.segment[1] === s.segment[1]
                     )
                 ) {
-                    sponsorTimesSubmitting.push({
+                    contentState.sponsorTimesSubmitting.push({
                         cid: getCid(),
                         segment: segment.segment,
                         UUID: generateUserID() as SegmentUUID,
@@ -2925,7 +2801,7 @@ function checkForPreloadedSegment() {
     }
 
     if (pushed) {
-        Config.local.unsubmittedSegments[getVideoID()] = sponsorTimesSubmitting;
+        Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
         Config.forceLocalUpdate("unsubmittedSegments");
     }
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -6,10 +6,11 @@ import {
     setupPageLoadingListener,
 } from "./content/state";
 import { initDanmakuSkip } from "./content/danmakuSkip";
-import { initVideoListeners, setupVideoListeners } from "./content/videoListeners";
+import { initVideoListeners, resetVideoListenerState, setupVideoListeners } from "./content/videoListeners";
 import {
     checkPreviewbarState,
     createPreviewBar,
+    getPreviewBar,
     initPreviewBarManager,
     removeDurationAfterSkip,
     selectSegment,
@@ -21,6 +22,7 @@ import {
     initSkipScheduler,
     isSegmentMarkedNearCurrentTime,
     previewTime,
+    resetSponsorSkipped,
     reskipSponsorTime,
     skipToTime,
     startSkipScheduleCheckingForStartSponsors,
@@ -34,7 +36,10 @@ import {
     clearSponsorTimes,
     closeInfoMenu,
     dontShowNoticeAgain,
+    getCategoryPill,
     getRealCurrentTime,
+    getSkipButtonControlBar,
+    getSubmissionNotice,
     initSegmentSubmission,
     isSegmentCreationInProgress,
     openInfoMenu,
@@ -155,7 +160,7 @@ const skipNoticeContentContainer: ContentContainer = () => ({
     sponsorVideoID: getVideoID(),
     reskipSponsorTime,
     updatePreviewBar,
-    sponsorSubmissionNotice: contentState.submissionNotice,
+    sponsorSubmissionNotice: getSubmissionNotice(),
     resetSponsorSubmissionNotice,
     updateEditButtonsOnPlayer: updateSegmentSubmitting,
     previewTime,
@@ -206,12 +211,11 @@ initMessageHandler({
 setupMessageListener();
 
 function resetValues() {
-    contentState.lastCheckTime = 0;
-    contentState.lastCheckVideoTime = -1;
+    resetVideoListenerState();
     contentState.previewedSegment = false;
 
     contentState.sponsorTimes = [];
-    contentState.sponsorSkipped = [];
+    resetSponsorSkipped();
     contentState.lastResponseStatus = 0;
     contentState.shownSegmentFailedToFetchWarning = false;
 
@@ -220,8 +224,8 @@ function resetValues() {
     contentState.lockedCategories = [];
 
     //empty the preview bar
-    if (contentState.previewBar !== null) {
-        contentState.previewBar.clear();
+    if (getPreviewBar() !== null) {
+        getPreviewBar().clear();
     }
 
     // resetDurationAfterSkip
@@ -238,8 +242,8 @@ function resetValues() {
         logDebug("Setting switching videos to true (reset data)");
     }
 
-    contentState.skipButtonControlBar?.disable();
-    contentState.categoryPill?.resetSegment();
+    getSkipButtonControlBar()?.disable();
+    getCategoryPill()?.resetSegment();
 
     for (let i = 0; i < contentState.skipNotices.length; i++) {
         contentState.skipNotices.pop()?.close();
@@ -253,7 +257,7 @@ function resetValues() {
 
 async function videoIDChange(): Promise<void> {
     //setup the preview bar
-    if (contentState.previewBar === null) {
+    if (getPreviewBar() === null) {
         waitFor(getControls).then(createPreviewBar);
     }
 

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,6 +1,6 @@
 import SkipNoticeComponent from "./components/SkipNoticeComponent";
 import Config from "./config";
-import { keybindToString, StorageChangesObject } from "./config/config";
+import { keybindToString } from "./config/config";
 import { ContentContainer } from "./ContentContainerTypes";
 import PreviewBar, { PreviewBarSegment } from "./js-components/previewBar";
 import { SkipButtonControlBar } from "./js-components/skipButtonControlBar";
@@ -15,7 +15,7 @@ import {
 import { danmakuForSkip, initDanmakuSkip } from "./content/danmakuSkip";
 import { initMessageHandler, setupMessageListener } from "./content/messageHandler";
 import { addHotkeyListener, initHotkeyHandler, seekFrameByKeyPressListener } from "./content/hotkeyHandler";
-import { Message, MessageResponse, VoteResponse } from "./messageTypes";
+import { VoteResponse } from "./messageTypes";
 import advanceSkipNotice from "./render/advanceSkipNotice";
 import { CategoryPill } from "./render/CategoryPill";
 import { ChapterVote } from "./render/ChapterVote";
@@ -57,7 +57,6 @@ import { defaultPreviewTime } from "./utils/constants";
 import { parseTargetTimeFromDanmaku } from "./utils/danmakusUtils";
 import { findValidElement } from "./utils/dom";
 import { durationEquals } from "./utils/duraionUtils";
-import { importTimes } from "./utils/exporter";
 import { getErrorMessage, getFormattedTime } from "./utils/formating";
 import { GenericUtils } from "./utils/genericUtils";
 import { getHash, getVideoIDHash, HashedValue } from "./utils/hash";
@@ -164,240 +163,28 @@ const skipNoticeContentContainer: ContentContainer = () => ({
     channelIDInfo: getChannelIDInfo(),
 });
 
-//get messages from the background script and the popup
-chrome.runtime.onMessage.addListener(messageListener);
-
-async function messageListener(
-    request: Message,
-    sender: unknown,
-    sendResponse: (response: MessageResponse) => void
-): Promise<void | boolean> {
-    //messages from popup script
-    switch (request.message) {
-        case "update":
-            checkVideoIDChange();
-            break;
-        case "sponsorStart":
-            startOrEndTimingNewSegment();
-
-            sendResponse({
-                creatingSegment: isSegmentCreationInProgress(),
-            });
-
-            break;
-        case "isInfoFound":
-            if (!contentState.lastResponseStatus) return;
-
-            //send the sponsor times along with if it's found
-            sendResponse({
-                found: contentState.sponsorDataFound,
-                status: contentState.lastResponseStatus,
-                sponsorTimes: contentState.sponsorTimes,
-                portVideo: contentState.portVideo,
-                time: getVideo()?.currentTime ?? 0,
-            });
-
-            if (
-                !request.updating &&
-                contentState.popupInitialised &&
-                document.getElementById("sponsorBlockPopupContainer") != null
-            ) {
-                //the popup should be closed now that another is opening
-                closeInfoMenu();
-            }
-
-            contentState.popupInitialised = true;
-            break;
-        case "getVideoID":
-            {
-                let id = getVideoID();
-                if (!id) {
-                    id = await getBilibiliVideoID();
-                    if (id) {
-                        await videoIDChange();
-                    }
-                }
-                sendResponse({
-                    videoID: id,
-                });
-            }
-
-            break;
-        case "getChannelID":
-            sendResponse({
-                channelID: getChannelIDInfo().id,
-            });
-
-            break;
-        case "getChannelInfo":
-            {
-                const channelID = getChannelIDInfo().id;
-                let channelName = chrome.i18n.getMessage("whitelistUnknownUploader") || "Unknown UP";
-
-                // Try to get channel name from the page
-                const upNameElement = document.querySelector("a.up-name");
-                if (upNameElement && upNameElement.textContent) {
-                    channelName = upNameElement.textContent.trim();
-                }
-
-                sendResponse({
-                    channelID,
-                    channelName,
-                });
-            }
-            break;
-        case "isChannelWhitelisted":
-            sendResponse({
-                value: contentState.channelWhitelisted,
-            });
-
-            break;
-        case "whitelistChange":
-            contentState.channelWhitelisted = request.value;
-            sponsorsLookup();
-
-            break;
-        case "submitTimes":
-            openSubmissionMenu();
-            break;
-        case "refreshSegments":
-            // update video on refresh if videoID invalid
-            if (!getVideoID()) {
-                checkVideoIDChange();
-            }
-
-            // if popup rescieves no response, or the videoID is invalid,
-            // it will assume the page is not a video page and stop the refresh animation
-            sendResponse({ hasVideo: getVideoID() != null });
-            // fetch segments
-            sponsorsLookup(false, true);
-
-            break;
-        case "unskip":
-            unskipSponsorTime(
-                contentState.sponsorTimes.find((segment) => segment.UUID === request.UUID),
-                null,
-                true
-            );
-            break;
-        case "reskip":
-            reskipSponsorTime(
-                contentState.sponsorTimes.find((segment) => segment.UUID === request.UUID),
-                true
-            );
-            break;
-        case "selectSegment":
-            selectSegment(request.UUID);
-            break;
-        case "submitVote":
-            vote(request.type, request.UUID).then((response) => sendResponse(response));
-            return true;
-        case "hideSegment":
-            utils.getSponsorTimeFromUUID(contentState.sponsorTimes, request.UUID).hidden = request.type;
-            utils.addHiddenSegment(getVideoID(), request.UUID, request.type);
-            updatePreviewBar();
-
-            if (
-                contentState.skipButtonControlBar?.isEnabled() &&
-                contentState.sponsorTimesSubmitting.every(
-                    (s) => s.hidden !== SponsorHideType.Visible || s.actionType !== ActionType.Poi
-                )
-            ) {
-                contentState.skipButtonControlBar.disable();
-            }
-            break;
-        case "closePopup":
-            closeInfoMenu();
-            break;
-        case "copyToClipboard":
-            navigator.clipboard.writeText(request.text);
-            break;
-        case "importSegments": {
-            const importedSegments = importTimes(request.data, getVideo().duration);
-            let addedSegments = false;
-            for (const segment of importedSegments) {
-                if (
-                    !contentState.sponsorTimesSubmitting.some(
-                        (s) =>
-                            Math.abs(s.segment[0] - segment.segment[0]) < 1 &&
-                            Math.abs(s.segment[1] - segment.segment[1]) < 1
-                    )
-                ) {
-                    contentState.sponsorTimesSubmitting.push(segment);
-                    addedSegments = true;
-                }
-            }
-
-            if (addedSegments) {
-                Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
-                Config.forceLocalUpdate("unsubmittedSegments");
-
-                updateSegmentSubmitting();
-                updateSponsorTimesSubmitting(false);
-                openSubmissionMenu();
-            }
-
-            sendResponse({
-                importedSegments,
-            });
-            break;
-        }
-        case "keydown":
-            (document.body || document).dispatchEvent(
-                new KeyboardEvent("keydown", {
-                    key: request.key,
-                    keyCode: request.keyCode,
-                    code: request.code,
-                    which: request.which,
-                    shiftKey: request.shiftKey,
-                    ctrlKey: request.ctrlKey,
-                    altKey: request.altKey,
-                    metaKey: request.metaKey,
-                })
-            );
-            break;
-        case "submitPortVideo":
-            submitPortVideo(request.ytbID);
-            break;
-        case "votePortVideo":
-            portVideoVote(request.UUID, request.vote);
-            break;
-        case "updatePortedSegments":
-            updateSegments(request.UUID);
-            break;
-    }
-
-    sendResponse({});
-}
-
-/**
- * Called when the config is updated
- */
-function contentConfigUpdateListener(changes: StorageChangesObject) {
-    for (const key in changes) {
-        switch (key) {
-            case "hideVideoPlayerControls":
-            case "hideInfoButtonPlayerControls":
-            case "hideDeleteButtonPlayerControls":
-                updateVisibilityOfPlayerControlsButton();
-                break;
-            case "categorySelections":
-                sponsorsLookup();
-                break;
-            case "barTypes":
-                setCategoryColorCSSVariables();
-                break;
-            case "fullVideoSegments":
-            case "fullVideoLabelsOnThumbnails":
-                checkPageForNewThumbnails();
-                break;
-        }
-    }
-}
-
-if (!Config.configSyncListeners.includes(contentConfigUpdateListener)) {
-    Config.configSyncListeners.push(contentConfigUpdateListener);
-}
+initMessageHandler({
+    startOrEndTimingNewSegment,
+    isSegmentCreationInProgress,
+    closeInfoMenu,
+    openSubmissionMenu,
+    videoIDChange,
+    selectSegment,
+    vote,
+    updatePreviewBar,
+    updateSegmentSubmitting,
+    updateSponsorTimesSubmitting,
+    unskipSponsorTime,
+    reskipSponsorTime,
+    sponsorsLookup,
+    submitPortVideo,
+    portVideoVote,
+    updateSegments,
+    updateVisibilityOfPlayerControlsButton,
+    setCategoryColorCSSVariables,
+    utils,
+});
+setupMessageListener();
 
 function resetValues() {
     contentState.lastCheckTime = 0;

--- a/src/content/danmakuSkip.ts
+++ b/src/content/danmakuSkip.ts
@@ -1,0 +1,112 @@
+import Config from "../config";
+import { contentState } from "./state";
+import {
+    ActionType,
+    Category,
+    SegmentUUID,
+    SkipToTimeParams,
+    SponsorSourceType,
+    SponsorTime,
+} from "../types";
+import { addCleanupListener } from "../utils/cleanup";
+import { parseTargetTimeFromDanmaku } from "../utils/danmakusUtils";
+import { getCid, getVideo } from "../utils/video";
+import { generateUserID } from "../utils/setup";
+
+export interface DanmakuSkipDeps {
+    getVirtualTime: () => number;
+    isSegmentMarkedNearCurrentTime: (currentTime: number, range?: number) => boolean;
+    skipToTime: (params: SkipToTimeParams) => void;
+    openSubmissionMenu: () => void;
+}
+
+let danmakuObserver: MutationObserver = null;
+const processedDanmaku = new Set<string>();
+
+let deps: DanmakuSkipDeps;
+
+export function initDanmakuSkip(d: DanmakuSkipDeps): void {
+    deps = d;
+}
+
+function checkDanmaku(text: string, offset: number) {
+    const targetTime = parseTargetTimeFromDanmaku(text, deps.getVirtualTime());
+    if (targetTime === null) return;
+
+    const startTime = deps.getVirtualTime() + offset;
+
+    if (targetTime < startTime + 5) return;
+    if (targetTime > getVideo().duration) return;
+
+    if (Config.config.checkTimeDanmakuSkip && deps.isSegmentMarkedNearCurrentTime(startTime)) return;
+
+    const skippingSegments: SponsorTime[] = [
+        {
+            cid: getCid(),
+            actionType: ActionType.Skip,
+            segment: [startTime, targetTime],
+            source: SponsorSourceType.Danmaku,
+            UUID: generateUserID() as SegmentUUID,
+            category: "sponsor" as Category,
+        },
+    ];
+
+    setTimeout(() => {
+        deps.skipToTime({
+            v: getVideo(),
+            skipTime: [startTime, targetTime],
+            skippingSegments,
+            openNotice: true,
+            forceAutoSkip: Config.config.enableAutoSkipDanmakuSkip,
+            unskipTime: startTime,
+        });
+        if (Config.config.enableMenuDanmakuSkip) {
+            setTimeout(() => {
+                if (!contentState.sponsorTimesSubmitting?.some((s) => s.segment[1] === skippingSegments[0].segment[1])) {
+                    contentState.sponsorTimesSubmitting.push(skippingSegments[0]);
+                }
+                deps.openSubmissionMenu();
+            }, Config.config.skipNoticeDuration * 1000 + 500);
+        }
+    }, offset * 1000 - 100);
+}
+
+export function danmakuForSkip(): void {
+    if (!Config.config.enableDanmakuSkip || Config.config.disableSkipping) return;
+    if (danmakuObserver) return;
+
+    const targetNode = document.querySelector(".bpx-player-row-dm-wrap");
+    const config = { attributes: true, subtree: true };
+    const callback = (mutationsList: MutationRecord[]) => {
+        if (!Config.config.enableDanmakuSkip || Config.config.disableSkipping) return;
+        if (targetNode.classList.contains("bili-danmaku-x-paused")) return;
+        for (const mutation of mutationsList) {
+            const target = mutation.target as HTMLElement;
+            if (mutation.type === "attributes" && target.classList.contains("bili-danmaku-x-dm")) {
+                const content = mutation.target.textContent;
+                if (target.classList.contains("bili-danmaku-x-show")) {
+                    if (!content || processedDanmaku.has(content)) {
+                        continue;
+                    }
+                    processedDanmaku.add(content);
+                    const offset = target.classList.contains("bili-danmaku-x-center") ? 0.3 : 1;
+                    checkDanmaku(content, offset);
+                } else {
+                    if (!content || processedDanmaku.has(content)) {
+                        processedDanmaku.delete(content);
+                    }
+                }
+            }
+        }
+    };
+    danmakuObserver = new MutationObserver(callback);
+    danmakuObserver.observe(targetNode, config);
+    addCleanupListener(() => {
+        if (danmakuObserver) {
+            danmakuObserver.disconnect();
+            danmakuObserver = null;
+            processedDanmaku.clear();
+            return;
+        }
+    });
+}

--- a/src/content/hotkeyHandler.ts
+++ b/src/content/hotkeyHandler.ts
@@ -3,6 +3,7 @@ import { Keybind, keybindEquals } from "../config/config";
 import Utils from "../utils";
 import { addCleanupListener } from "../utils/cleanup";
 import { getFrameRate, getVideo } from "../utils/video";
+import { getSkipButtonControlBar } from "./segmentSubmission";
 import { contentState } from "./state";
 
 export interface HotkeyHandlerDeps {
@@ -83,8 +84,8 @@ function hotkeyListener(e: KeyboardEvent): void {
 
         return;
     } else if (keybindEquals(key, skipToHighlightKey)) {
-        if (contentState.skipButtonControlBar) {
-            contentState.skipButtonControlBar.toggleSkip.call(contentState.skipButtonControlBar);
+        if (getSkipButtonControlBar()) {
+            getSkipButtonControlBar().toggleSkip.call(getSkipButtonControlBar());
         }
 
         return;

--- a/src/content/hotkeyHandler.ts
+++ b/src/content/hotkeyHandler.ts
@@ -1,0 +1,130 @@
+import Config from "../config";
+import { Keybind, keybindEquals } from "../config/config";
+import Utils from "../utils";
+import { addCleanupListener } from "../utils/cleanup";
+import { getFrameRate, getVideo } from "../utils/video";
+import { contentState } from "./state";
+
+export interface HotkeyHandlerDeps {
+    startOrEndTimingNewSegment: () => void;
+    submitSegments: () => void;
+    openSubmissionMenu: () => void;
+    previewRecentSegment: () => void;
+}
+
+let deps: HotkeyHandlerDeps;
+const utils = new Utils();
+
+export function initHotkeyHandler(d: HotkeyHandlerDeps): void {
+    deps = d;
+}
+
+export function addHotkeyListener(): void {
+    document.addEventListener("keydown", hotkeyListener);
+
+    const onLoad = () => {
+        document.removeEventListener("keydown", hotkeyListener);
+        document.body.addEventListener("keydown", hotkeyListener);
+
+        addCleanupListener(() => {
+            document.body.removeEventListener("keydown", hotkeyListener);
+        });
+    };
+
+    if (document.readyState === "complete") {
+        onLoad();
+    } else {
+        document.addEventListener("DOMContentLoaded", onLoad);
+    }
+}
+
+function hotkeyListener(e: KeyboardEvent): void {
+    if (
+        ["textarea", "input"].includes(document.activeElement?.tagName?.toLowerCase()) ||
+        document.activeElement?.id?.toLowerCase()?.includes("editable")
+    )
+        return;
+
+    const key: Keybind = {
+        key: e.key,
+        code: e.code,
+        alt: e.altKey,
+        ctrl: e.ctrlKey,
+        shift: e.shiftKey,
+    };
+
+    const skipKey = Config.config.skipKeybind;
+    const skipToHighlightKey = Config.config.skipToHighlightKeybind;
+    const closeSkipNoticeKey = Config.config.closeSkipNoticeKeybind;
+    const startSponsorKey = Config.config.startSponsorKeybind;
+    const submitKey = Config.config.actuallySubmitKeybind;
+    const previewKey = Config.config.previewKeybind;
+    const openSubmissionMenuKey = Config.config.submitKeybind;
+
+    if (keybindEquals(key, skipKey)) {
+        if (contentState.activeSkipKeybindElement) {
+            contentState.activeSkipKeybindElement.toggleSkip.call(contentState.activeSkipKeybindElement);
+
+            /*
+             * 视频播放器全屏或网页全屏时，快捷键`Enter`会聚焦到弹幕输入框
+             * 这里阻止了使用`Enter`跳过赞助片段时播放器的默认行为
+             */
+            if (key.key === 'Enter') {
+                const currentTime: number | null = document.querySelector<HTMLVideoElement>(".bpx-player-video-wrap video")?.currentTime ?? null;
+                if (currentTime) {
+                    const inSponsorRange = contentState.sponsorTimes.some(({ segment: [start, end] }) => start <= currentTime && end >= currentTime);
+                    if (inSponsorRange) {
+                        utils.biliBiliPlayerDanmakuInputBlur();
+                    }
+                }
+
+            }
+        }
+
+        return;
+    } else if (keybindEquals(key, skipToHighlightKey)) {
+        if (contentState.skipButtonControlBar) {
+            contentState.skipButtonControlBar.toggleSkip.call(contentState.skipButtonControlBar);
+        }
+
+        return;
+    } else if (keybindEquals(key, closeSkipNoticeKey)) {
+        for (let i = 0; i < contentState.skipNotices.length; i++) {
+            contentState.skipNotices.pop().close();
+        }
+
+        return;
+    } else if (keybindEquals(key, startSponsorKey)) {
+        deps.startOrEndTimingNewSegment();
+        return;
+    } else if (keybindEquals(key, submitKey)) {
+        deps.submitSegments();
+        return;
+    } else if (keybindEquals(key, openSubmissionMenuKey)) {
+        e.preventDefault();
+
+        deps.openSubmissionMenu();
+        return;
+    } else if (keybindEquals(key, previewKey)) {
+        deps.previewRecentSegment();
+        return;
+    }
+}
+
+/**
+ * Hot keys to jump to the next or previous frame, for easier segment time editting
+ * only effective when the SubmissionNotice is open
+ *
+ * @param key keydown event
+ */
+export function seekFrameByKeyPressListener(key) {
+    const vid = getVideo();
+    const frameRate = getFrameRate();
+    if (!vid.paused) return;
+
+    if (keybindEquals(key, Config.config.nextFrameKeybind)) {
+        vid.currentTime += 1 / frameRate;
+    } else if (keybindEquals(key, Config.config.previousFrameKeybind)) {
+        vid.currentTime -= 1 / frameRate;
+    }
+}

--- a/src/content/messageHandler.ts
+++ b/src/content/messageHandler.ts
@@ -15,6 +15,7 @@ import Utils from "../utils";
 import { importTimes } from "../utils/exporter";
 import { getBilibiliVideoID } from "../utils/parseVideoID";
 import { checkVideoIDChange, getChannelIDInfo, getVideo, getVideoID } from "../utils/video";
+import { getPopupInitialised, getSkipButtonControlBar, setPopupInitialised } from "./segmentSubmission";
 import { contentState } from "./state";
 
 export interface MessageHandlerDeps {
@@ -82,13 +83,13 @@ async function messageListener(
 
             if (
                 !request.updating &&
-                contentState.popupInitialised &&
+                getPopupInitialised() &&
                 document.getElementById("sponsorBlockPopupContainer") != null
             ) {
                 deps.closeInfoMenu();
             }
 
-            contentState.popupInitialised = true;
+            setPopupInitialised(true);
             break;
         case "getVideoID":
             {
@@ -175,12 +176,12 @@ async function messageListener(
             deps.updatePreviewBar();
 
             if (
-                contentState.skipButtonControlBar?.isEnabled() &&
+                getSkipButtonControlBar()?.isEnabled() &&
                 contentState.sponsorTimesSubmitting.every(
                     (s) => s.hidden !== SponsorHideType.Visible || s.actionType !== ActionType.Poi
                 )
             ) {
-                contentState.skipButtonControlBar.disable();
+                getSkipButtonControlBar().disable();
             }
             break;
         case "closePopup":

--- a/src/content/messageHandler.ts
+++ b/src/content/messageHandler.ts
@@ -1,0 +1,270 @@
+import Config from "../config";
+import { StorageChangesObject } from "../config/config";
+import { Message, MessageResponse, VoteResponse } from "../messageTypes";
+import { checkPageForNewThumbnails } from "../thumbnail-utils/thumbnailManagement";
+import {
+    ActionType,
+    Category,
+    PortVideo,
+    SegmentUUID,
+    SponsorHideType,
+    SponsorTime,
+    YTID,
+} from "../types";
+import Utils from "../utils";
+import { importTimes } from "../utils/exporter";
+import { getBilibiliVideoID } from "../utils/parseVideoID";
+import { checkVideoIDChange, getChannelIDInfo, getVideo, getVideoID } from "../utils/video";
+import { contentState } from "./state";
+
+export interface MessageHandlerDeps {
+    startOrEndTimingNewSegment: () => void;
+    isSegmentCreationInProgress: () => boolean;
+    closeInfoMenu: () => void;
+    openSubmissionMenu: () => void;
+    videoIDChange: () => Promise<void>;
+    selectSegment: (UUID: SegmentUUID) => void;
+    vote: (type: number, UUID: SegmentUUID, category?: Category) => Promise<VoteResponse>;
+    updatePreviewBar: () => void;
+    updateSegmentSubmitting: () => void;
+    updateSponsorTimesSubmitting: (getFromConfig?: boolean) => void;
+    unskipSponsorTime: (segment: SponsorTime, unskipTime?: number, forceSeek?: boolean) => void;
+    reskipSponsorTime: (segment: SponsorTime, forceSeek?: boolean) => void;
+    sponsorsLookup: (keepOldSubmissions?: boolean, ignoreServerCache?: boolean, forceUpdatePreviewBar?: boolean) => void;
+    submitPortVideo: (ytbID: YTID) => Promise<PortVideo>;
+    portVideoVote: (UUID: string, vote: number) => void;
+    updateSegments: (UUID: string) => void;
+    updateVisibilityOfPlayerControlsButton: () => void;
+    setCategoryColorCSSVariables: () => void;
+    utils: Utils;
+}
+
+let deps: MessageHandlerDeps;
+
+export function initMessageHandler(dependencies: MessageHandlerDeps): void {
+    deps = dependencies;
+}
+
+export function setupMessageListener(): void {
+    chrome.runtime.onMessage.addListener(messageListener);
+    if (!Config.configSyncListeners.includes(contentConfigUpdateListener)) {
+        Config.configSyncListeners.push(contentConfigUpdateListener);
+    }
+}
+
+async function messageListener(
+    request: Message,
+    sender: unknown,
+    sendResponse: (response: MessageResponse) => void
+): Promise<void | boolean> {
+    switch (request.message) {
+        case "update":
+            checkVideoIDChange();
+            break;
+        case "sponsorStart":
+            deps.startOrEndTimingNewSegment();
+
+            sendResponse({
+                creatingSegment: deps.isSegmentCreationInProgress(),
+            });
+
+            break;
+        case "isInfoFound":
+            if (!contentState.lastResponseStatus) return;
+
+            sendResponse({
+                found: contentState.sponsorDataFound,
+                status: contentState.lastResponseStatus,
+                sponsorTimes: contentState.sponsorTimes,
+                portVideo: contentState.portVideo,
+                time: getVideo()?.currentTime ?? 0,
+            });
+
+            if (
+                !request.updating &&
+                contentState.popupInitialised &&
+                document.getElementById("sponsorBlockPopupContainer") != null
+            ) {
+                deps.closeInfoMenu();
+            }
+
+            contentState.popupInitialised = true;
+            break;
+        case "getVideoID":
+            {
+                let id = getVideoID();
+                if (!id) {
+                    id = await getBilibiliVideoID();
+                    if (id) {
+                        await deps.videoIDChange();
+                    }
+                }
+                sendResponse({
+                    videoID: id,
+                });
+            }
+
+            break;
+        case "getChannelID":
+            sendResponse({
+                channelID: getChannelIDInfo().id,
+            });
+
+            break;
+        case "getChannelInfo":
+            {
+                const channelID = getChannelIDInfo().id;
+                let channelName = chrome.i18n.getMessage("whitelistUnknownUploader") || "Unknown UP";
+
+                const upNameElement = document.querySelector("a.up-name");
+                if (upNameElement && upNameElement.textContent) {
+                    channelName = upNameElement.textContent.trim();
+                }
+
+                sendResponse({
+                    channelID,
+                    channelName,
+                });
+            }
+            break;
+        case "isChannelWhitelisted":
+            sendResponse({
+                value: contentState.channelWhitelisted,
+            });
+
+            break;
+        case "whitelistChange":
+            contentState.channelWhitelisted = request.value;
+            deps.sponsorsLookup();
+
+            break;
+        case "submitTimes":
+            deps.openSubmissionMenu();
+            break;
+        case "refreshSegments":
+            if (!getVideoID()) {
+                checkVideoIDChange();
+            }
+
+            sendResponse({ hasVideo: getVideoID() != null });
+            deps.sponsorsLookup(false, true);
+
+            break;
+        case "unskip":
+            deps.unskipSponsorTime(
+                contentState.sponsorTimes.find((segment) => segment.UUID === request.UUID),
+                null,
+                true
+            );
+            break;
+        case "reskip":
+            deps.reskipSponsorTime(
+                contentState.sponsorTimes.find((segment) => segment.UUID === request.UUID),
+                true
+            );
+            break;
+        case "selectSegment":
+            deps.selectSegment(request.UUID);
+            break;
+        case "submitVote":
+            deps.vote(request.type, request.UUID).then((response) => sendResponse(response));
+            return true;
+        case "hideSegment":
+            deps.utils.getSponsorTimeFromUUID(contentState.sponsorTimes, request.UUID).hidden = request.type;
+            deps.utils.addHiddenSegment(getVideoID(), request.UUID, request.type);
+            deps.updatePreviewBar();
+
+            if (
+                contentState.skipButtonControlBar?.isEnabled() &&
+                contentState.sponsorTimesSubmitting.every(
+                    (s) => s.hidden !== SponsorHideType.Visible || s.actionType !== ActionType.Poi
+                )
+            ) {
+                contentState.skipButtonControlBar.disable();
+            }
+            break;
+        case "closePopup":
+            deps.closeInfoMenu();
+            break;
+        case "copyToClipboard":
+            navigator.clipboard.writeText(request.text);
+            break;
+        case "importSegments": {
+            const importedSegments = importTimes(request.data, getVideo().duration);
+            let addedSegments = false;
+            for (const segment of importedSegments) {
+                if (
+                    !contentState.sponsorTimesSubmitting.some(
+                        (s) =>
+                            Math.abs(s.segment[0] - segment.segment[0]) < 1 &&
+                            Math.abs(s.segment[1] - segment.segment[1]) < 1
+                    )
+                ) {
+                    contentState.sponsorTimesSubmitting.push(segment);
+                    addedSegments = true;
+                }
+            }
+
+            if (addedSegments) {
+                Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
+                Config.forceLocalUpdate("unsubmittedSegments");
+
+                deps.updateSegmentSubmitting();
+                deps.updateSponsorTimesSubmitting(false);
+                deps.openSubmissionMenu();
+            }
+
+            sendResponse({
+                importedSegments,
+            });
+            break;
+        }
+        case "keydown":
+            (document.body || document).dispatchEvent(
+                new KeyboardEvent("keydown", {
+                    key: request.key,
+                    keyCode: request.keyCode,
+                    code: request.code,
+                    which: request.which,
+                    shiftKey: request.shiftKey,
+                    ctrlKey: request.ctrlKey,
+                    altKey: request.altKey,
+                    metaKey: request.metaKey,
+                })
+            );
+            break;
+        case "submitPortVideo":
+            deps.submitPortVideo(request.ytbID);
+            break;
+        case "votePortVideo":
+            deps.portVideoVote(request.UUID, request.vote);
+            break;
+        case "updatePortedSegments":
+            deps.updateSegments(request.UUID);
+            break;
+    }
+
+    sendResponse({});
+}
+
+function contentConfigUpdateListener(changes: StorageChangesObject) {
+    for (const key in changes) {
+        switch (key) {
+            case "hideVideoPlayerControls":
+            case "hideInfoButtonPlayerControls":
+            case "hideDeleteButtonPlayerControls":
+                deps.updateVisibilityOfPlayerControlsButton();
+                break;
+            case "categorySelections":
+                deps.sponsorsLookup();
+                break;
+            case "barTypes":
+                deps.setCategoryColorCSSVariables();
+                break;
+            case "fullVideoSegments":
+            case "fullVideoLabelsOnThumbnails":
+                checkPageForNewThumbnails();
+                break;
+        }
+    }
+}

--- a/src/content/messageHandler.ts
+++ b/src/content/messageHandler.ts
@@ -53,11 +53,11 @@ export function setupMessageListener(): void {
     }
 }
 
-async function messageListener(
+function messageListener(
     request: Message,
     sender: unknown,
     sendResponse: (response: MessageResponse) => void
-): Promise<void | boolean> {
+): void | boolean {
     switch (request.message) {
         case "update":
             checkVideoIDChange();
@@ -92,20 +92,21 @@ async function messageListener(
             setPopupInitialised(true);
             break;
         case "getVideoID":
-            {
+            (async () => {
                 let id = getVideoID();
                 if (!id) {
                     id = await getBilibiliVideoID();
-                    if (id) {
-                        await deps.videoIDChange();
-                    }
+                    if (id) await deps.videoIDChange();
                 }
-                sendResponse({
+                return {
                     videoID: id,
+                };
+            })()
+                .then(sendResponse)
+                .catch((e) => {
+                    console.error("get video id failed: ", e);
                 });
-            }
-
-            break;
+            return true;
         case "getChannelID":
             sendResponse({
                 channelID: getChannelIDInfo().id,
@@ -168,7 +169,7 @@ async function messageListener(
             deps.selectSegment(request.UUID);
             break;
         case "submitVote":
-            deps.vote(request.type, request.UUID).then((response) => sendResponse(response));
+            deps.vote(request.type, request.UUID).then(sendResponse);
             return true;
         case "hideSegment":
             deps.utils.getSponsorTimeFromUUID(contentState.sponsorTimes, request.UUID).hidden = request.type;

--- a/src/content/previewBarManager.ts
+++ b/src/content/previewBarManager.ts
@@ -2,7 +2,7 @@ import Config from "../config";
 import PreviewBar, { PreviewBarSegment } from "../js-components/previewBar";
 import { VoteResponse } from "../messageTypes";
 import { ChapterVote } from "../render/ChapterVote";
-import { ActionType, Category, SegmentUUID, SponsorHideType } from "../types";
+import { ActionType, BVID, Category, SegmentUUID, SponsorHideType } from "../types";
 import Utils from "../utils";
 import { waitFor } from "../utils/";
 import { findValidElement } from "../utils/dom";
@@ -12,6 +12,22 @@ import { getVideo, getVideoID } from "../utils/video";
 import { contentState } from "./state";
 
 const utils = new Utils();
+
+// --- Module-private state (formerly on contentState) ---
+let previewBar: PreviewBar = null;
+let selectedSegment: SegmentUUID | null = null;
+let lastPreviewBarUpdate: BVID;
+
+export function getPreviewBar() { return previewBar; }
+export function getLastPreviewBarUpdate() { return lastPreviewBarUpdate; }
+
+export function resetPreviewBarState(): void {
+    if (previewBar) {
+        previewBar.remove();
+        previewBar = null;
+    }
+    selectedSegment = null;
+}
 
 let _voteAsync: (type: number, UUID: SegmentUUID, category?: Category) => Promise<VoteResponse | undefined>;
 let _updateVisibilityOfPlayerControlsButton: () => Promise<void>;
@@ -27,7 +43,7 @@ export function initPreviewBarManager(deps: {
 export const durationID = "sponsorBlockDurationAfterSkips";
 
 export function createPreviewBar(): void {
-    if (contentState.previewBar !== null) return;
+    if (previewBar !== null) return;
 
     const progressElementOptions = [
         {
@@ -45,7 +61,7 @@ export function createPreviewBar(): void {
 
         if (parent) {
             const chapterVote = new ChapterVote(_voteAsync);
-            contentState.previewBar = new PreviewBar(parent, shadowParent, chapterVote);
+            previewBar = new PreviewBar(parent, shadowParent, chapterVote);
             updatePreviewBar();
             break;
         }
@@ -53,7 +69,7 @@ export function createPreviewBar(): void {
 }
 
 export function updatePreviewBar(): void {
-    if (contentState.previewBar === null) return;
+    if (previewBar === null) return;
     if (getVideo() === null) return;
 
     const hashParams = getHashParams();
@@ -72,7 +88,7 @@ export function updatePreviewBar(): void {
                 source: segment.source,
                 requiredSegment:
                     requiredSegment && (segment.UUID === requiredSegment || segment.UUID?.startsWith(requiredSegment)),
-                selectedSegment: contentState.selectedSegment && segment.UUID === contentState.selectedSegment,
+                selectedSegment: selectedSegment && segment.UUID === selectedSegment,
             });
         });
     }
@@ -88,7 +104,7 @@ export function updatePreviewBar(): void {
         });
     });
 
-    contentState.previewBar.set(
+    previewBar.set(
         previewBarSegments.filter((segment) => segment.actionType !== ActionType.Full),
         getVideo()?.duration
     );
@@ -105,13 +121,13 @@ export function updatePreviewBar(): void {
         showTimeWithoutSkips(skippedDuration);
     }
 
-    contentState.lastPreviewBarUpdate = getVideoID();
+    lastPreviewBarUpdate = getVideoID();
 }
 
 export function checkPreviewbarState(): void {
-    if (contentState.previewBar && !utils.findReferenceNode()?.contains(contentState.previewBar.container)) {
-        contentState.previewBar.remove();
-        contentState.previewBar = null;
+    if (previewBar && !utils.findReferenceNode()?.contains(previewBar.container)) {
+        previewBar.remove();
+        previewBar = null;
         removeDurationAfterSkip();
     }
 
@@ -119,12 +135,12 @@ export function checkPreviewbarState(): void {
 }
 
 export function selectSegment(UUID: SegmentUUID): void {
-    contentState.selectedSegment = UUID;
+    selectedSegment = UUID;
     updatePreviewBar();
 }
 
 export function updateActiveSegment(currentTime: number): void {
-    contentState.previewBar?.updateChapterText(contentState.sponsorTimes, contentState.sponsorTimesSubmitting, currentTime);
+    previewBar?.updateChapterText(contentState.sponsorTimes, contentState.sponsorTimesSubmitting, currentTime);
 
     chrome.runtime.sendMessage({
         message: "time",

--- a/src/content/previewBarManager.ts
+++ b/src/content/previewBarManager.ts
@@ -1,0 +1,169 @@
+import Config from "../config";
+import PreviewBar, { PreviewBarSegment } from "../js-components/previewBar";
+import { VoteResponse } from "../messageTypes";
+import { ChapterVote } from "../render/ChapterVote";
+import { ActionType, Category, SegmentUUID, SponsorHideType } from "../types";
+import Utils from "../utils";
+import { waitFor } from "../utils/";
+import { findValidElement } from "../utils/dom";
+import { getFormattedTime } from "../utils/formating";
+import { getHashParams } from "../utils/pageUtils";
+import { getVideo, getVideoID } from "../utils/video";
+import { contentState } from "./state";
+
+const utils = new Utils();
+
+let _voteAsync: (type: number, UUID: SegmentUUID, category?: Category) => Promise<VoteResponse | undefined>;
+let _updateVisibilityOfPlayerControlsButton: () => Promise<void>;
+
+export function initPreviewBarManager(deps: {
+    voteAsync: (type: number, UUID: SegmentUUID, category?: Category) => Promise<VoteResponse | undefined>;
+    updateVisibilityOfPlayerControlsButton: () => Promise<void>;
+}): void {
+    _voteAsync = deps.voteAsync;
+    _updateVisibilityOfPlayerControlsButton = deps.updateVisibilityOfPlayerControlsButton;
+}
+
+export const durationID = "sponsorBlockDurationAfterSkips";
+
+export function createPreviewBar(): void {
+    if (contentState.previewBar !== null) return;
+
+    const progressElementOptions = [
+        {
+            selector: ".bpx-player-progress",
+            shadowSelector: ".bpx-player-shadow-progress-area",
+            isVisibleCheck: true,
+        },
+    ];
+
+    for (const option of progressElementOptions) {
+        const allElements = document.querySelectorAll(option.selector) as NodeListOf<HTMLElement>;
+        const parent = option.isVisibleCheck ? findValidElement(allElements) : allElements[0];
+        const allshadowSelectorElements = document.querySelectorAll(option.shadowSelector) as NodeListOf<HTMLElement>;
+        const shadowParent = allshadowSelectorElements[0];
+
+        if (parent) {
+            const chapterVote = new ChapterVote(_voteAsync);
+            contentState.previewBar = new PreviewBar(parent, shadowParent, chapterVote);
+            updatePreviewBar();
+            break;
+        }
+    }
+}
+
+export function updatePreviewBar(): void {
+    if (contentState.previewBar === null) return;
+    if (getVideo() === null) return;
+
+    const hashParams = getHashParams();
+    const requiredSegment = (hashParams?.requiredSegment as SegmentUUID) || undefined;
+    const previewBarSegments: PreviewBarSegment[] = [];
+    if (contentState.sponsorTimes) {
+        contentState.sponsorTimes.forEach((segment) => {
+            if (segment.hidden !== SponsorHideType.Visible) return;
+
+            previewBarSegments.push({
+                segment: segment.segment as [number, number],
+                category: segment.category,
+                actionType: segment.actionType,
+                unsubmitted: false,
+                showLarger: segment.actionType === ActionType.Poi,
+                source: segment.source,
+                requiredSegment:
+                    requiredSegment && (segment.UUID === requiredSegment || segment.UUID?.startsWith(requiredSegment)),
+                selectedSegment: contentState.selectedSegment && segment.UUID === contentState.selectedSegment,
+            });
+        });
+    }
+
+    contentState.sponsorTimesSubmitting.forEach((segment) => {
+        previewBarSegments.push({
+            segment: segment.segment as [number, number],
+            category: segment.category,
+            actionType: segment.actionType,
+            unsubmitted: true,
+            showLarger: segment.actionType === ActionType.Poi,
+            source: segment.source,
+        });
+    });
+
+    contentState.previewBar.set(
+        previewBarSegments.filter((segment) => segment.actionType !== ActionType.Full),
+        getVideo()?.duration
+    );
+    if (getVideo()) updateActiveSegment(getVideo().currentTime);
+
+    _updateVisibilityOfPlayerControlsButton();
+
+    removeDurationAfterSkip();
+    if (Config.config.showTimeWithSkips) {
+        const skippedDuration = utils.getTimestampsDuration(
+            previewBarSegments.filter(({ actionType }) => actionType !== ActionType.Mute).map(({ segment }) => segment)
+        );
+
+        showTimeWithoutSkips(skippedDuration);
+    }
+
+    contentState.lastPreviewBarUpdate = getVideoID();
+}
+
+export function checkPreviewbarState(): void {
+    if (contentState.previewBar && !utils.findReferenceNode()?.contains(contentState.previewBar.container)) {
+        contentState.previewBar.remove();
+        contentState.previewBar = null;
+        removeDurationAfterSkip();
+    }
+
+    waitFor(() => !document.hidden, 24 * 60 * 60, 500).then(createPreviewBar);
+}
+
+export function selectSegment(UUID: SegmentUUID): void {
+    contentState.selectedSegment = UUID;
+    updatePreviewBar();
+}
+
+export function updateActiveSegment(currentTime: number): void {
+    contentState.previewBar?.updateChapterText(contentState.sponsorTimes, contentState.sponsorTimesSubmitting, currentTime);
+
+    chrome.runtime.sendMessage({
+        message: "time",
+        time: currentTime,
+    });
+}
+
+export function showTimeWithoutSkips(skippedDuration: number): void {
+    if (isNaN(skippedDuration) || skippedDuration < 0) {
+        skippedDuration = 0;
+    }
+
+    const display = document.querySelector(".bpx-player-ctrl-time-label") as HTMLDivElement;
+    if (!display) return;
+
+    let duration = document.getElementById(durationID);
+
+    if (duration === null) {
+        duration = document.createElement("span");
+        duration.id = durationID;
+        display.appendChild(duration);
+    }
+
+    const durationAfterSkips = getFormattedTime(getVideo()?.duration - skippedDuration);
+
+    const refreshDurationTextWidth = () => {
+        display.style.width = "auto";
+        display.parentElement.style.minWidth = `${display.clientWidth - 11}px`;
+    };
+
+    if (durationAfterSkips != null && skippedDuration > 0) {
+        duration.innerText = " (" + durationAfterSkips + ")";
+
+        refreshDurationTextWidth();
+        window.addEventListener("fullscreenchange", refreshDurationTextWidth);
+    }
+}
+
+export function removeDurationAfterSkip(): void {
+    const duration = document.getElementById(durationID);
+    duration?.remove();
+}

--- a/src/content/segmentSubmission.ts
+++ b/src/content/segmentSubmission.ts
@@ -1,0 +1,772 @@
+import SkipNoticeComponent from "../components/SkipNoticeComponent";
+import Config from "../config";
+import { keybindToString } from "../config/config";
+import { ContentContainer } from "../ContentContainerTypes";
+import { SkipButtonControlBar } from "../js-components/skipButtonControlBar";
+import { VoteResponse } from "../messageTypes";
+import { CategoryPill } from "../render/CategoryPill";
+import { DescriptionPortPill } from "../render/DescriptionPortPill";
+import { showMessage } from "../render/MessageNotice";
+import { PlayerButton } from "../render/PlayerButton";
+import SubmissionNotice from "../render/SubmissionNotice";
+import { getPortVideoByHash, postPortVideo, postPortVideoVote, updatePortedSegments } from "../requests/portVideo";
+import { asyncRequestToServer } from "../requests/requests";
+import { getSegmentsByVideoID } from "../requests/segments";
+import { FetchResponse } from "../requests/type/requestType";
+import { getVideoLabel } from "../requests/videoLabels";
+import {
+    ActionType,
+    BVID,
+    Category,
+    NewVideoID,
+    PortVideo,
+    SegmentUUID,
+    SkipToTimeParams,
+    SponsorHideType,
+    SponsorSourceType,
+    SponsorTime,
+    YTID,
+} from "../types";
+import Utils from "../utils";
+import { waitFor } from "../utils/";
+import { AnimationUtils } from "../utils/animationUtils";
+import { defaultPreviewTime } from "../utils/constants";
+import { durationEquals } from "../utils/duraionUtils";
+import { getErrorMessage, getFormattedTime } from "../utils/formating";
+import { getHash, getVideoIDHash, HashedValue } from "../utils/hash";
+import { getCidMapFromWindow } from "../utils/injectedScriptMessageUtils";
+import { getHashParams } from "../utils/pageUtils";
+import { generateUserID } from "../utils/setup";
+import { getBvID, getCid, getVideo, getVideoID, waitForVideo } from "../utils/video";
+import { parseBvidAndCidFromVideoId } from "../utils/videoIdUtils";
+import { openWarningDialog } from "../utils/warnings";
+import { contentState } from "./state";
+
+const utils = new Utils();
+
+export interface SegmentSubmissionDeps {
+    skipToTime: (params: SkipToTimeParams) => void;
+    startSponsorSchedule: (seekTime?: boolean, seekToTime?: number) => void;
+    previewTime: (time: number, showNotice?: boolean) => void;
+    startSkipScheduleCheckingForStartSponsors: () => void;
+    updatePreviewBar: () => void;
+    selectSegment: (UUID: SegmentUUID) => void;
+    seekFrameByKeyPressListener: (event: KeyboardEvent) => void;
+    playerButton: PlayerButton;
+    skipNoticeContentContainer: ContentContainer;
+}
+
+let deps: SegmentSubmissionDeps;
+
+export function initSegmentSubmission(d: SegmentSubmissionDeps): void {
+    deps = d;
+}
+
+export function setupSkipButtonControlBar(): void {
+    if (!contentState.skipButtonControlBar) {
+        contentState.skipButtonControlBar = new SkipButtonControlBar({
+            skip: (segment) =>
+                deps.skipToTime({
+                    v: getVideo(),
+                    skipTime: segment.segment,
+                    skippingSegments: [segment],
+                    openNotice: true,
+                    forceAutoSkip: true,
+                }),
+            selectSegment: deps.selectSegment,
+        });
+    }
+
+    contentState.skipButtonControlBar.attachToPage();
+}
+
+export function setupCategoryPill(): void {
+    if (!contentState.categoryPill) {
+        contentState.categoryPill = new CategoryPill();
+    }
+
+    contentState.categoryPill.attachToPage(voteAsync);
+}
+
+export function setupDescriptionPill(): void {
+    if (!contentState.descriptionPill) {
+        contentState.descriptionPill = new DescriptionPortPill(
+            getPortVideo,
+            submitPortVideo,
+            portVideoVote,
+            updateSegments,
+            sponsorsLookup
+        );
+    }
+    contentState.descriptionPill.setupDescription(getVideoID());
+}
+
+export async function updatePortVideoElements(newPortVideo: PortVideo): Promise<void> {
+    contentState.portVideo = newPortVideo;
+    waitFor(() => contentState.descriptionPill).then(() => contentState.descriptionPill.setPortVideoData(newPortVideo));
+
+    chrome.runtime.sendMessage({
+        message: "infoUpdated",
+        found: contentState.sponsorDataFound,
+        status: contentState.lastResponseStatus,
+        sponsorTimes: contentState.sponsorTimes,
+        portVideo: newPortVideo,
+        time: getVideo()?.currentTime ?? 0,
+    });
+}
+
+export async function getPortVideo(videoId: NewVideoID, bypassCache = false): Promise<void> {
+    const newPortVideo = await getPortVideoByHash(videoId, { bypassCache });
+    if (newPortVideo?.UUID === contentState.portVideo?.UUID) return;
+    contentState.portVideo = newPortVideo;
+
+    updatePortVideoElements(contentState.portVideo);
+}
+
+export async function submitPortVideo(ytbID: YTID): Promise<PortVideo> {
+    const newPortVideo = await postPortVideo(getVideoID(), ytbID, getVideo()?.duration);
+    contentState.portVideo = newPortVideo;
+    updatePortVideoElements(contentState.portVideo);
+    sponsorsLookup(true, true, true);
+    return newPortVideo;
+}
+
+export async function portVideoVote(UUID: string, voteType: number): Promise<void> {
+    await postPortVideoVote(UUID, getVideoID(), voteType);
+    await getPortVideo(getVideoID(), true);
+}
+
+export async function updateSegments(UUID: string): Promise<FetchResponse> {
+    const response = await updatePortedSegments(getVideoID(), UUID);
+    if (response.ok) {
+        sponsorsLookup(true, true, true);
+    }
+    return response;
+}
+
+export async function sponsorsLookup(keepOldSubmissions = true, ignoreServerCache = false, forceUpdatePreviewBar = false): Promise<void> {
+    const videoID = getVideoID();
+    const { bvId, cid } = parseBvidAndCidFromVideoId(videoID);
+    if (!videoID) {
+        console.error("[SponsorBlock] Attempted to fetch segments with a null/undefined videoID.");
+        return;
+    }
+    if (contentState.lookupWaiting) return;
+
+    if (!getVideo()) {
+        await waitForVideo();
+
+        contentState.lookupWaiting = true;
+        setTimeout(() => {
+            contentState.lookupWaiting = false;
+            sponsorsLookup(keepOldSubmissions, ignoreServerCache, forceUpdatePreviewBar);
+        }, 100);
+        return;
+    }
+
+    const extraRequestData: Record<string, unknown> = {};
+    const hashParams = getHashParams();
+    if (hashParams.requiredSegment) extraRequestData.requiredSegment = hashParams.requiredSegment;
+
+    const hashPrefix = (await getVideoIDHash(videoID)).slice(0, 4) as BVID & HashedValue;
+    const segmentResponse = await getSegmentsByVideoID(videoID, extraRequestData, ignoreServerCache);
+
+    if (videoID !== getVideoID()) return;
+
+    contentState.lastResponseStatus = segmentResponse?.status;
+
+    if (segmentResponse.status === 200) {
+        let receivedSegments: SponsorTime[] = segmentResponse.segments?.filter(segment => segment.cid === cid);
+
+        const uniqueCids = new Set(segmentResponse?.segments?.filter((segment) => durationEquals(segment.videoDuration, getVideo()?.duration, 5)).map(s => s.cid));
+        console.log("unique cids from segments", uniqueCids)
+        if (uniqueCids.size > 1) {
+            const cidMap = await getCidMapFromWindow(bvId);
+            console.log("[BSB] Multiple CIDs found, using the one from the window object", cidMap);
+            if (cidMap.size == 1) {
+                receivedSegments = segmentResponse.segments?.filter(segment => uniqueCids.has(segment.cid));
+            }
+        }
+
+        if (receivedSegments && receivedSegments.length) {
+            contentState.sponsorDataFound = true;
+
+            if (contentState.sponsorTimes !== null && keepOldSubmissions) {
+                for (let i = 0; i < contentState.sponsorTimes.length; i++) {
+                    if (contentState.sponsorTimes[i].source === SponsorSourceType.Local) {
+                        receivedSegments.push(contentState.sponsorTimes[i]);
+                    }
+                }
+            }
+
+            const oldSegments = contentState.sponsorTimes || [];
+            contentState.sponsorTimes = receivedSegments;
+
+            if (Config.config.minDuration !== 0) {
+                for (const segment of contentState.sponsorTimes) {
+                    const duration = segment.segment[1] - segment.segment[0];
+                    if (duration > 0 && duration < Config.config.minDuration) {
+                        segment.hidden = SponsorHideType.MinimumDuration;
+                    }
+                }
+            }
+
+            if (keepOldSubmissions) {
+                for (const segment of oldSegments) {
+                    const otherSegment = contentState.sponsorTimes.find((other) => segment.UUID === other.UUID);
+                    if (otherSegment) {
+                        otherSegment.hidden = segment.hidden;
+                        otherSegment.category = segment.category;
+                    }
+                }
+            }
+
+            const downvotedData = Config.local.downvotedSegments[hashPrefix];
+            if (downvotedData) {
+                for (const segment of contentState.sponsorTimes) {
+                    const hashedUUID = await getHash(segment.UUID, 1);
+                    const segmentDownvoteData = downvotedData.segments.find((downvote) => downvote.uuid === hashedUUID);
+                    if (segmentDownvoteData) {
+                        segment.hidden = segmentDownvoteData.hidden;
+                    }
+                }
+            }
+
+            deps.startSkipScheduleCheckingForStartSponsors();
+
+            if (
+                forceUpdatePreviewBar ||
+                contentState.lastPreviewBarUpdate == getVideoID() ||
+                (contentState.lastPreviewBarUpdate == null && !isNaN(getVideo().duration))
+            ) {
+                deps.updatePreviewBar();
+            }
+        }
+    }
+
+    chrome.runtime.sendMessage({
+        message: "infoUpdated",
+        found: contentState.sponsorDataFound,
+        status: contentState.lastResponseStatus,
+        sponsorTimes: contentState.sponsorTimes,
+        portVideo: contentState.portVideo,
+        time: getVideo()?.currentTime ?? 0,
+    });
+
+    if (Config.config.isVip) {
+        lockedCategoriesLookup();
+    }
+}
+
+export async function lockedCategoriesLookup(): Promise<void> {
+    const hashPrefix = (await getHash(getVideoID(), 1)).slice(0, 4);
+    const response = await asyncRequestToServer("GET", "/api/lockCategories/" + hashPrefix);
+
+    if (response.ok) {
+        try {
+            const categoriesResponse = JSON.parse(response.responseText).filter(
+                (lockInfo) => lockInfo.videoID === getVideoID()
+            )[0]?.categories;
+            if (Array.isArray(categoriesResponse)) {
+                contentState.lockedCategories = categoriesResponse;
+            }
+        } catch (e) { } //eslint-disable-line no-empty
+    }
+}
+
+/** Creates any missing buttons on the player and updates their visiblity. */
+export async function updateVisibilityOfPlayerControlsButton(): Promise<void> {
+    if (!getVideoID()) return;
+
+    contentState.playerButtons = await deps.playerButton.createButtons();
+
+    updateSegmentSubmitting();
+}
+
+/** Updates the visibility of buttons on the player related to creating segments. */
+export function updateSegmentSubmitting(): void {
+    if (!getVideoID()) return;
+    deps.playerButton.updateSegmentSubmitting(contentState.sponsorTimesSubmitting);
+}
+
+/**
+ * Used for submitting. This will use the HTML displayed number when required as the video's
+ * current time is out of date while scrubbing or at the end of the getVideo(). This is not needed
+ * for sponsor skipping as the video is not playing during these times.
+ */
+export function getRealCurrentTime(): number {
+    const endingDataSelect = document.querySelector(".bpx-player-ending-wrap")?.getAttribute("data-select");
+
+    if (endingDataSelect === "1") {
+        return getVideo()?.duration;
+    } else {
+        return getVideo().currentTime;
+    }
+}
+
+export function startOrEndTimingNewSegment(): void {
+    const roundedTime = Math.round((getRealCurrentTime() + Number.EPSILON) * 1000) / 1000;
+    if (!isSegmentCreationInProgress()) {
+        contentState.sponsorTimesSubmitting.push({
+            cid: getCid(),
+            segment: [roundedTime],
+            UUID: generateUserID() as SegmentUUID,
+            category: Config.config.defaultCategory,
+            actionType: ActionType.Skip,
+            source: SponsorSourceType.Local,
+        });
+    } else {
+        const existingSegment = getIncompleteSegment();
+        const existingTime = existingSegment.segment[0];
+        const currentTime = roundedTime;
+
+        existingSegment.segment = [Math.min(existingTime, currentTime), Math.max(existingTime, currentTime)];
+    }
+
+    Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
+    Config.forceLocalUpdate("unsubmittedSegments");
+
+    sponsorsLookup(true, true);
+
+    updateSegmentSubmitting();
+    updateSponsorTimesSubmitting(false);
+
+    if (
+        contentState.lastResponseStatus !== 200 &&
+        contentState.lastResponseStatus !== 404 &&
+        !contentState.shownSegmentFailedToFetchWarning &&
+        Config.config.showSegmentFailedToFetchWarning
+    ) {
+        showMessage(chrome.i18n.getMessage("segmentFetchFailureWarning"), "warning");
+
+        contentState.shownSegmentFailedToFetchWarning = true;
+    }
+}
+
+export function getIncompleteSegment(): SponsorTime {
+    return contentState.sponsorTimesSubmitting[contentState.sponsorTimesSubmitting.length - 1];
+}
+
+/** Is the latest submitting segment incomplete */
+export function isSegmentCreationInProgress(): boolean {
+    const segment = getIncompleteSegment();
+    return segment && segment?.segment?.length !== 2;
+}
+
+export function cancelCreatingSegment(): void {
+    if (isSegmentCreationInProgress()) {
+        if (contentState.sponsorTimesSubmitting.length > 1) {
+            contentState.sponsorTimesSubmitting.pop();
+            Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
+        } else {
+            resetSponsorSubmissionNotice();
+            contentState.sponsorTimesSubmitting = [];
+            delete Config.local.unsubmittedSegments[getVideoID()];
+        }
+        Config.forceLocalUpdate("unsubmittedSegments");
+    }
+
+    updateSegmentSubmitting();
+    updateSponsorTimesSubmitting(false);
+}
+
+export function updateSponsorTimesSubmitting(getFromConfig = true): void {
+    const segmentTimes = Config.local.unsubmittedSegments[getVideoID()];
+
+    if (getFromConfig && segmentTimes != undefined) {
+        contentState.sponsorTimesSubmitting = [];
+
+        for (const segmentTime of segmentTimes) {
+            contentState.sponsorTimesSubmitting.push({
+                cid: getCid(),
+                segment: segmentTime.segment,
+                UUID: segmentTime.UUID,
+                category: segmentTime.category,
+                actionType: segmentTime.actionType,
+                source: segmentTime.source,
+            });
+        }
+
+        if (contentState.sponsorTimesSubmitting.length > 0) {
+            contentState.previewedSegment = true;
+        }
+    }
+
+    deps.updatePreviewBar();
+
+    if (getVideo() !== null) deps.startSponsorSchedule();
+
+    if (contentState.submissionNotice !== null) {
+        contentState.submissionNotice.update();
+    }
+
+    checkForPreloadedSegment();
+}
+
+export function openInfoMenu(): void {
+    if (document.getElementById("sponsorBlockPopupContainer") != null) {
+        return;
+    }
+
+    contentState.popupInitialised = false;
+
+    const popup = document.createElement("div");
+    popup.id = "sponsorBlockPopupContainer";
+
+    const frame = document.createElement("iframe");
+    frame.width = "374";
+    frame.height = "500";
+    frame.style.borderRadius = "6px";
+    frame.style.margin = "0px auto 20px";
+    frame.addEventListener("load", async () => {
+        frame.contentWindow.postMessage("", "*");
+
+        const stylusStyle = document.querySelector(".stylus");
+        if (stylusStyle) {
+            frame.contentWindow.postMessage(
+                {
+                    type: "style",
+                    css: stylusStyle.textContent,
+                },
+                "*"
+            );
+        }
+    });
+    frame.src = chrome.runtime.getURL("popup.html");
+    popup.appendChild(frame);
+
+    const container = document.querySelector("#danmukuBox") as HTMLElement;
+    container.prepend(popup);
+}
+
+export function closeInfoMenu(): void {
+    const popup = document.getElementById("sponsorBlockPopupContainer");
+    if (popup === null) return;
+
+    popup.remove();
+
+    window.dispatchEvent(new Event("closePopupMenu"));
+}
+
+export function clearSponsorTimes(): void {
+    const currentVideoID = getVideoID();
+
+    const sponsorTimes = Config.local.unsubmittedSegments[currentVideoID];
+
+    if (sponsorTimes != undefined && sponsorTimes.length > 0) {
+        resetSponsorSubmissionNotice();
+
+        delete Config.local.unsubmittedSegments[currentVideoID];
+        Config.forceLocalUpdate("unsubmittedSegments");
+
+        contentState.sponsorTimesSubmitting = [];
+
+        deps.updatePreviewBar();
+        updateSegmentSubmitting();
+    }
+}
+
+export async function vote(
+    type: number,
+    UUID: SegmentUUID,
+    category?: Category,
+    skipNotice?: SkipNoticeComponent
+): Promise<VoteResponse> {
+    if (skipNotice !== null && skipNotice !== undefined) {
+        skipNotice.addVoteButtonInfo.bind(skipNotice)(chrome.i18n.getMessage("Loading"));
+        skipNotice.setNoticeInfoMessage.bind(skipNotice)();
+    }
+
+    const response = await voteAsync(type, UUID, category);
+    if (response != undefined) {
+        if (skipNotice != null) {
+            if (response.successType == 1 || (response.successType == -1 && response.statusCode == 429)) {
+                skipNotice.afterVote.bind(skipNotice)(utils.getSponsorTimeFromUUID(contentState.sponsorTimes, UUID), type, category);
+            } else if (response.successType == -1) {
+                if (
+                    response.statusCode === 403 &&
+                    response.responseText.startsWith("Vote rejected due to a tip from a moderator.")
+                ) {
+                    openWarningDialog(deps.skipNoticeContentContainer);
+                } else {
+                    skipNotice.setNoticeInfoMessage.bind(skipNotice)(
+                        getErrorMessage(response.statusCode, response.responseText)
+                    );
+                }
+
+                skipNotice.resetVoteButtonInfo.bind(skipNotice)();
+            }
+        }
+    }
+
+    return response;
+}
+
+export async function voteAsync(type: number, UUID: SegmentUUID, category?: Category): Promise<VoteResponse | undefined> {
+    const sponsorIndex = utils.getSponsorIndexFromUUID(contentState.sponsorTimes, UUID);
+
+    if (sponsorIndex == -1 || contentState.sponsorTimes[sponsorIndex].source !== SponsorSourceType.Server)
+        return Promise.resolve(undefined);
+
+    if ((type === 0 && contentState.sponsorSkipped[sponsorIndex]) || (type === 1 && !contentState.sponsorSkipped[sponsorIndex])) {
+        let factor = 1;
+        if (type == 0) {
+            factor = -1;
+
+            contentState.sponsorSkipped[sponsorIndex] = false;
+        }
+
+        Config.config.minutesSaved =
+            Config.config.minutesSaved +
+            (factor * (contentState.sponsorTimes[sponsorIndex].segment[1] - contentState.sponsorTimes[sponsorIndex].segment[0])) / 60;
+
+        Config.config.skipCount = Config.config.skipCount + factor;
+    }
+
+    return new Promise((resolve) => {
+        chrome.runtime.sendMessage(
+            {
+                message: "submitVote",
+                type: type,
+                UUID: UUID,
+                category: category,
+            },
+            (response) => {
+                if (response.successType === 1) {
+                    const segment = utils.getSponsorTimeFromUUID(contentState.sponsorTimes, UUID);
+                    if (segment) {
+                        if (type === 0) {
+                            segment.hidden = SponsorHideType.Downvoted;
+                        } else if (category) {
+                            segment.category = category;
+                        } else if (type === 1) {
+                            segment.hidden = SponsorHideType.Visible;
+                        }
+
+                        if (!category && !Config.config.isVip) {
+                            utils.addHiddenSegment(getVideoID(), segment.UUID, segment.hidden);
+                        }
+
+                        deps.updatePreviewBar();
+                    }
+                }
+
+                resolve(response);
+            }
+        );
+    });
+}
+
+export function closeAllSkipNotices(): void {
+    const notices = document.getElementsByClassName("sponsorSkipNotice");
+    for (let i = 0; i < notices.length; i++) {
+        notices[i].remove();
+    }
+}
+
+export function dontShowNoticeAgain(): void {
+    Config.config.dontShowNotice = true;
+    closeAllSkipNotices();
+}
+
+/**
+ * Helper method for the submission notice to clear itself when it closes
+ */
+export function resetSponsorSubmissionNotice(callRef = true): void {
+    contentState.submissionNotice?.close(callRef);
+    contentState.submissionNotice = null;
+}
+
+export function closeSubmissionMenu(): void {
+    contentState.submissionNotice?.close();
+    contentState.submissionNotice = null;
+}
+
+export function openSubmissionMenu(): void {
+    if (contentState.submissionNotice !== null) {
+        closeSubmissionMenu();
+        return;
+    }
+
+    if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0) {
+        contentState.submissionNotice = new SubmissionNotice(deps.skipNoticeContentContainer, sendSubmitMessage);
+        document.addEventListener("keydown", deps.seekFrameByKeyPressListener);
+    }
+}
+
+export function previewRecentSegment(): void {
+    if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0) {
+        deps.previewTime(contentState.sponsorTimesSubmitting[contentState.sponsorTimesSubmitting.length - 1].segment[0] - defaultPreviewTime);
+
+        if (contentState.submissionNotice) {
+            contentState.submissionNotice.scrollToBottom();
+        }
+    }
+}
+
+export function submitSegments(): void {
+    if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0 && contentState.submissionNotice !== null) {
+        contentState.submissionNotice.submit();
+    }
+}
+
+export async function sendSubmitMessage(): Promise<boolean> {
+    if (
+        !contentState.previewedSegment &&
+        !contentState.sponsorTimesSubmitting.every(
+            (segment) =>
+                [ActionType.Full, ActionType.Poi].includes(segment.actionType) ||
+                segment.segment[1] >= getVideo()?.duration ||
+                segment.segment[0] === 0
+        )
+    ) {
+        showMessage(
+            `${chrome.i18n.getMessage("previewSegmentRequired")} ${keybindToString(Config.config.previewKeybind)}`,
+            "warning"
+        );
+        return false;
+    }
+
+    contentState.playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadIconSponsorBlocker.svg");
+    const stopAnimation = AnimationUtils.applyLoadingAnimation(contentState.playerButtons.submit.button, 1, () =>
+        updateSegmentSubmitting()
+    );
+
+    for (let i = 0; i < contentState.sponsorTimesSubmitting.length; i++) {
+        if (contentState.sponsorTimesSubmitting[i].segment[1] > getVideo().duration) {
+            contentState.sponsorTimesSubmitting[i].segment[1] = getVideo().duration;
+        }
+    }
+
+    Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
+    Config.forceLocalUpdate("unsubmittedSegments");
+
+    if (Config.config.minDuration > 0) {
+        for (let i = 0; i < contentState.sponsorTimesSubmitting.length; i++) {
+            const duration = contentState.sponsorTimesSubmitting[i].segment[1] - contentState.sponsorTimesSubmitting[i].segment[0];
+            if (duration > 0 && duration < Config.config.minDuration) {
+                const confirmShort =
+                    chrome.i18n.getMessage("shortCheck") + "\n\n" + getSegmentsMessage(contentState.sponsorTimesSubmitting);
+
+                if (!confirm(confirmShort)) return false;
+            }
+        }
+    }
+
+    const response = await asyncRequestToServer("POST", "/api/skipSegments", {
+        videoID: getBvID(),
+        cid: getCid(),
+        userID: Config.config.userID,
+        segments: contentState.sponsorTimesSubmitting,
+        videoDuration: getVideo()?.duration,
+        userAgent: `${chrome.runtime.id}/v${chrome.runtime.getManifest().version}`,
+    });
+
+    if (response.status === 200) {
+        stopAnimation();
+
+        delete Config.local.unsubmittedSegments[getVideoID()];
+        Config.forceLocalUpdate("unsubmittedSegments");
+
+        const newSegments = contentState.sponsorTimesSubmitting;
+        try {
+            const receivedNewSegments = JSON.parse(response.responseText);
+            if (receivedNewSegments?.length === newSegments.length) {
+                for (let i = 0; i < receivedNewSegments.length; i++) {
+                    newSegments[i].UUID = receivedNewSegments[i].UUID;
+                    newSegments[i].source = SponsorSourceType.Server;
+                }
+            }
+        } catch (e) { } // eslint-disable-line no-empty
+
+        contentState.sponsorTimes = (contentState.sponsorTimes || []).concat(newSegments).sort((a, b) => a.segment[0] - b.segment[0]);
+
+        Config.config.sponsorTimesContributed = Config.config.sponsorTimesContributed + contentState.sponsorTimesSubmitting.length;
+
+        Config.config.submissionCountSinceCategories = Config.config.submissionCountSinceCategories + 1;
+
+        contentState.sponsorTimesSubmitting = [];
+
+        deps.updatePreviewBar();
+
+        const fullVideoSegment = contentState.sponsorTimes.filter((time) => time.actionType === ActionType.Full)[0];
+        if (fullVideoSegment) {
+            waitFor(() => contentState.categoryPill).then(() => {
+                contentState.categoryPill?.setSegment(fullVideoSegment);
+            });
+            getVideoLabel(getVideoID(), true);
+        }
+
+        return true;
+    } else {
+        contentState.playerButtons.submit.button.style.animation = "unset";
+        contentState.playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadFailedIconSponsorBlocker.svg");
+
+        if (
+            response.status === 403 &&
+            response.responseText.startsWith("Submission rejected due to a tip from a moderator.")
+        ) {
+            openWarningDialog(deps.skipNoticeContentContainer);
+        } else {
+            showMessage(getErrorMessage(response.status, response.responseText), "warning");
+        }
+    }
+
+    return false;
+}
+
+export function getSegmentsMessage(sponsorTimes: SponsorTime[]): string {
+    let sponsorTimesMessage = "";
+
+    for (let i = 0; i < sponsorTimes.length; i++) {
+        for (let s = 0; s < sponsorTimes[i].segment.length; s++) {
+            let timeMessage = getFormattedTime(sponsorTimes[i].segment[s]);
+            if (s == 1) {
+                timeMessage = " " + chrome.i18n.getMessage("to") + " " + timeMessage;
+            } else if (i > 0) {
+                timeMessage = ", " + timeMessage;
+            }
+
+            sponsorTimesMessage += timeMessage;
+        }
+    }
+
+    return sponsorTimesMessage;
+}
+
+export function checkForPreloadedSegment(): void {
+    if (contentState.loadedPreloadedSegment) return;
+
+    contentState.loadedPreloadedSegment = true;
+    const hashParams = getHashParams();
+
+    let pushed = false;
+    const segments = hashParams.segments;
+    if (Array.isArray(segments)) {
+        for (const segment of segments) {
+            if (Array.isArray(segment.segment)) {
+                if (
+                    !contentState.sponsorTimesSubmitting.some(
+                        (s) => s.segment[0] === segment.segment[0] && s.segment[1] === s.segment[1]
+                    )
+                ) {
+                    contentState.sponsorTimesSubmitting.push({
+                        cid: getCid(),
+                        segment: segment.segment,
+                        UUID: generateUserID() as SegmentUUID,
+                        category: segment.category ? segment.category : Config.config.defaultCategory,
+                        actionType: segment.actionType ? segment.actionType : ActionType.Skip,
+                        source: SponsorSourceType.Local,
+                    });
+
+                    pushed = true;
+                }
+            }
+        }
+    }
+
+    if (pushed) {
+        Config.local.unsubmittedSegments[getVideoID()] = contentState.sponsorTimesSubmitting;
+        Config.forceLocalUpdate("unsubmittedSegments");
+    }
+}

--- a/src/content/segmentSubmission.ts
+++ b/src/content/segmentSubmission.ts
@@ -40,9 +40,41 @@ import { generateUserID } from "../utils/setup";
 import { getBvID, getCid, getVideo, getVideoID, waitForVideo } from "../utils/video";
 import { parseBvidAndCidFromVideoId } from "../utils/videoIdUtils";
 import { openWarningDialog } from "../utils/warnings";
+import { getLastPreviewBarUpdate } from "./previewBarManager";
+import { getSponsorSkipped } from "./skipScheduler";
 import { contentState } from "./state";
 
 const utils = new Utils();
+
+// --- Module-private state (formerly on contentState) ---
+let lookupWaiting = false;
+let loadedPreloadedSegment = false;
+let playerButtons: Record<string, { button: HTMLButtonElement; image: HTMLImageElement }> = {};
+let descriptionPill: DescriptionPortPill = null;
+let submissionNotice: SubmissionNotice = null;
+let popupInitialised = false;
+let skipButtonControlBar: SkipButtonControlBar = null;
+let categoryPill: CategoryPill = null;
+
+export function getSkipButtonControlBar() { return skipButtonControlBar; }
+export function getCategoryPill() { return categoryPill; }
+export function getPopupInitialised() { return popupInitialised; }
+export function setPopupInitialised(v: boolean) { popupInitialised = v; }
+export function getSubmissionNotice() { return submissionNotice; }
+
+export function resetSubmissionState(): void {
+    loadedPreloadedSegment = false;
+    lookupWaiting = false;
+    popupInitialised = false;
+    if (submissionNotice) {
+        submissionNotice.close();
+        submissionNotice = null;
+    }
+    playerButtons = {};
+    descriptionPill = null;
+    skipButtonControlBar = null;
+    categoryPill = null;
+}
 
 export interface SegmentSubmissionDeps {
     skipToTime: (params: SkipToTimeParams) => void;
@@ -63,8 +95,8 @@ export function initSegmentSubmission(d: SegmentSubmissionDeps): void {
 }
 
 export function setupSkipButtonControlBar(): void {
-    if (!contentState.skipButtonControlBar) {
-        contentState.skipButtonControlBar = new SkipButtonControlBar({
+    if (!skipButtonControlBar) {
+        skipButtonControlBar = new SkipButtonControlBar({
             skip: (segment) =>
                 deps.skipToTime({
                     v: getVideo(),
@@ -77,20 +109,20 @@ export function setupSkipButtonControlBar(): void {
         });
     }
 
-    contentState.skipButtonControlBar.attachToPage();
+    skipButtonControlBar.attachToPage();
 }
 
 export function setupCategoryPill(): void {
-    if (!contentState.categoryPill) {
-        contentState.categoryPill = new CategoryPill();
+    if (!categoryPill) {
+        categoryPill = new CategoryPill();
     }
 
-    contentState.categoryPill.attachToPage(voteAsync);
+    categoryPill.attachToPage(voteAsync);
 }
 
 export function setupDescriptionPill(): void {
-    if (!contentState.descriptionPill) {
-        contentState.descriptionPill = new DescriptionPortPill(
+    if (!descriptionPill) {
+        descriptionPill = new DescriptionPortPill(
             getPortVideo,
             submitPortVideo,
             portVideoVote,
@@ -98,12 +130,12 @@ export function setupDescriptionPill(): void {
             sponsorsLookup
         );
     }
-    contentState.descriptionPill.setupDescription(getVideoID());
+    descriptionPill.setupDescription(getVideoID());
 }
 
 export async function updatePortVideoElements(newPortVideo: PortVideo): Promise<void> {
     contentState.portVideo = newPortVideo;
-    waitFor(() => contentState.descriptionPill).then(() => contentState.descriptionPill.setPortVideoData(newPortVideo));
+    waitFor(() => descriptionPill).then(() => descriptionPill.setPortVideoData(newPortVideo));
 
     chrome.runtime.sendMessage({
         message: "infoUpdated",
@@ -151,14 +183,14 @@ export async function sponsorsLookup(keepOldSubmissions = true, ignoreServerCach
         console.error("[SponsorBlock] Attempted to fetch segments with a null/undefined videoID.");
         return;
     }
-    if (contentState.lookupWaiting) return;
+    if (lookupWaiting) return;
 
     if (!getVideo()) {
         await waitForVideo();
 
-        contentState.lookupWaiting = true;
+        lookupWaiting = true;
         setTimeout(() => {
-            contentState.lookupWaiting = false;
+            lookupWaiting = false;
             sponsorsLookup(keepOldSubmissions, ignoreServerCache, forceUpdatePreviewBar);
         }, 100);
         return;
@@ -236,8 +268,8 @@ export async function sponsorsLookup(keepOldSubmissions = true, ignoreServerCach
 
             if (
                 forceUpdatePreviewBar ||
-                contentState.lastPreviewBarUpdate == getVideoID() ||
-                (contentState.lastPreviewBarUpdate == null && !isNaN(getVideo().duration))
+                getLastPreviewBarUpdate() == getVideoID() ||
+                (getLastPreviewBarUpdate() == null && !isNaN(getVideo().duration))
             ) {
                 deps.updatePreviewBar();
             }
@@ -278,7 +310,7 @@ export async function lockedCategoriesLookup(): Promise<void> {
 export async function updateVisibilityOfPlayerControlsButton(): Promise<void> {
     if (!getVideoID()) return;
 
-    contentState.playerButtons = await deps.playerButton.createButtons();
+    playerButtons = await deps.playerButton.createButtons();
 
     updateSegmentSubmitting();
 }
@@ -396,8 +428,8 @@ export function updateSponsorTimesSubmitting(getFromConfig = true): void {
 
     if (getVideo() !== null) deps.startSponsorSchedule();
 
-    if (contentState.submissionNotice !== null) {
-        contentState.submissionNotice.update();
+    if (submissionNotice !== null) {
+        submissionNotice.update();
     }
 
     checkForPreloadedSegment();
@@ -408,7 +440,7 @@ export function openInfoMenu(): void {
         return;
     }
 
-    contentState.popupInitialised = false;
+    popupInitialised = false;
 
     const popup = document.createElement("div");
     popup.id = "sponsorBlockPopupContainer";
@@ -508,12 +540,12 @@ export async function voteAsync(type: number, UUID: SegmentUUID, category?: Cate
     if (sponsorIndex == -1 || contentState.sponsorTimes[sponsorIndex].source !== SponsorSourceType.Server)
         return Promise.resolve(undefined);
 
-    if ((type === 0 && contentState.sponsorSkipped[sponsorIndex]) || (type === 1 && !contentState.sponsorSkipped[sponsorIndex])) {
+    if ((type === 0 && getSponsorSkipped()[sponsorIndex]) || (type === 1 && !getSponsorSkipped()[sponsorIndex])) {
         let factor = 1;
         if (type == 0) {
             factor = -1;
 
-            contentState.sponsorSkipped[sponsorIndex] = false;
+            getSponsorSkipped()[sponsorIndex] = false;
         }
 
         Config.config.minutesSaved =
@@ -573,23 +605,23 @@ export function dontShowNoticeAgain(): void {
  * Helper method for the submission notice to clear itself when it closes
  */
 export function resetSponsorSubmissionNotice(callRef = true): void {
-    contentState.submissionNotice?.close(callRef);
-    contentState.submissionNotice = null;
+    submissionNotice?.close(callRef);
+    submissionNotice = null;
 }
 
 export function closeSubmissionMenu(): void {
-    contentState.submissionNotice?.close();
-    contentState.submissionNotice = null;
+    submissionNotice?.close();
+    submissionNotice = null;
 }
 
 export function openSubmissionMenu(): void {
-    if (contentState.submissionNotice !== null) {
+    if (submissionNotice !== null) {
         closeSubmissionMenu();
         return;
     }
 
     if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0) {
-        contentState.submissionNotice = new SubmissionNotice(deps.skipNoticeContentContainer, sendSubmitMessage);
+        submissionNotice = new SubmissionNotice(deps.skipNoticeContentContainer, sendSubmitMessage);
         document.addEventListener("keydown", deps.seekFrameByKeyPressListener);
     }
 }
@@ -598,15 +630,15 @@ export function previewRecentSegment(): void {
     if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0) {
         deps.previewTime(contentState.sponsorTimesSubmitting[contentState.sponsorTimesSubmitting.length - 1].segment[0] - defaultPreviewTime);
 
-        if (contentState.submissionNotice) {
-            contentState.submissionNotice.scrollToBottom();
+        if (submissionNotice) {
+            submissionNotice.scrollToBottom();
         }
     }
 }
 
 export function submitSegments(): void {
-    if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0 && contentState.submissionNotice !== null) {
-        contentState.submissionNotice.submit();
+    if (contentState.sponsorTimesSubmitting !== undefined && contentState.sponsorTimesSubmitting.length > 0 && submissionNotice !== null) {
+        submissionNotice.submit();
     }
 }
 
@@ -627,8 +659,8 @@ export async function sendSubmitMessage(): Promise<boolean> {
         return false;
     }
 
-    contentState.playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadIconSponsorBlocker.svg");
-    const stopAnimation = AnimationUtils.applyLoadingAnimation(contentState.playerButtons.submit.button, 1, () =>
+    playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadIconSponsorBlocker.svg");
+    const stopAnimation = AnimationUtils.applyLoadingAnimation(playerButtons.submit.button, 1, () =>
         updateSegmentSubmitting()
     );
 
@@ -691,16 +723,16 @@ export async function sendSubmitMessage(): Promise<boolean> {
 
         const fullVideoSegment = contentState.sponsorTimes.filter((time) => time.actionType === ActionType.Full)[0];
         if (fullVideoSegment) {
-            waitFor(() => contentState.categoryPill).then(() => {
-                contentState.categoryPill?.setSegment(fullVideoSegment);
+            waitFor(() => categoryPill).then(() => {
+                categoryPill?.setSegment(fullVideoSegment);
             });
             getVideoLabel(getVideoID(), true);
         }
 
         return true;
     } else {
-        contentState.playerButtons.submit.button.style.animation = "unset";
-        contentState.playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadFailedIconSponsorBlocker.svg");
+        playerButtons.submit.button.style.animation = "unset";
+        playerButtons.submit.image.src = chrome.runtime.getURL("icons/PlayerUploadFailedIconSponsorBlocker.svg");
 
         if (
             response.status === 403 &&
@@ -735,9 +767,9 @@ export function getSegmentsMessage(sponsorTimes: SponsorTime[]): string {
 }
 
 export function checkForPreloadedSegment(): void {
-    if (contentState.loadedPreloadedSegment) return;
+    if (loadedPreloadedSegment) return;
 
-    contentState.loadedPreloadedSegment = true;
+    loadedPreloadedSegment = true;
     const hashParams = getHashParams();
 
     let pushed = false;

--- a/src/content/skipScheduler.ts
+++ b/src/content/skipScheduler.ts
@@ -27,6 +27,7 @@ import {
     getVideo,
     getVideoID,
 } from "../utils/video";
+import { getCategoryPill, getSkipButtonControlBar } from "./segmentSubmission";
 import {
     contentState,
     endTimeSkipBuffer,
@@ -35,6 +36,51 @@ import {
 } from "./state";
 
 const utils = new Utils();
+
+// --- Module-private state (formerly on contentState) ---
+let currentSkipSchedule: NodeJS.Timeout = null;
+let currentSkipInterval: NodeJS.Timeout = null;
+let currentVirtualTimeInterval: NodeJS.Timeout = null;
+let currentadvanceSkipSchedule: NodeJS.Timeout = null;
+let lastTimeFromWaitingEvent: number = null;
+let videoMuted = false;
+const lastKnownVideoTime: { videoTime: number; preciseTime: number; fromPause: boolean; approximateDelay: number } = {
+    videoTime: null,
+    preciseTime: null,
+    fromPause: false,
+    approximateDelay: null,
+};
+let sponsorSkipped: boolean[] = [];
+
+export function getLastKnownVideoTime() { return lastKnownVideoTime; }
+export function getSponsorSkipped() { return sponsorSkipped; }
+export function resetSponsorSkipped() { sponsorSkipped = []; }
+
+export function resetSchedulerState(): void {
+    if (currentSkipSchedule !== null) {
+        clearTimeout(currentSkipSchedule);
+        currentSkipSchedule = null;
+    }
+    if (currentSkipInterval !== null) {
+        clearInterval(currentSkipInterval);
+        currentSkipInterval = null;
+    }
+    if (currentVirtualTimeInterval !== null) {
+        clearInterval(currentVirtualTimeInterval);
+        currentVirtualTimeInterval = null;
+    }
+    if (currentadvanceSkipSchedule !== null) {
+        clearTimeout(currentadvanceSkipSchedule);
+        currentadvanceSkipSchedule = null;
+    }
+    lastTimeFromWaitingEvent = null;
+    videoMuted = false;
+    lastKnownVideoTime.videoTime = null;
+    lastKnownVideoTime.preciseTime = null;
+    lastKnownVideoTime.fromPause = false;
+    lastKnownVideoTime.approximateDelay = null;
+    sponsorSkipped = [];
+}
 
 export interface SkipSchedulerDeps {
     skipNoticeContentContainer: ContentContainer;
@@ -50,19 +96,19 @@ export function initSkipScheduler(d: SkipSchedulerDeps): void {
 export function cancelSponsorSchedule(): void {
     logDebug("Pausing skipping");
 
-    if (contentState.currentSkipSchedule !== null) {
-        clearTimeout(contentState.currentSkipSchedule);
-        contentState.currentSkipSchedule = null;
+    if (currentSkipSchedule !== null) {
+        clearTimeout(currentSkipSchedule);
+        currentSkipSchedule = null;
     }
 
-    if (contentState.currentSkipInterval !== null) {
-        clearInterval(contentState.currentSkipInterval);
-        contentState.currentSkipInterval = null;
+    if (currentSkipInterval !== null) {
+        clearInterval(currentSkipInterval);
+        currentSkipInterval = null;
     }
 
-    if (contentState.currentadvanceSkipSchedule !== null) {
-        clearInterval(contentState.currentadvanceSkipSchedule);
-        contentState.currentadvanceSkipSchedule = null;
+    if (currentadvanceSkipSchedule !== null) {
+        clearInterval(currentadvanceSkipSchedule);
+        currentadvanceSkipSchedule = null;
     }
 }
 
@@ -100,14 +146,14 @@ export async function startSponsorSchedule(
     const videoID = getVideoID();
 
     if (
-        contentState.videoMuted &&
+        videoMuted &&
         !inMuteSegment(
             currentTime,
             skipInfo.index !== -1 && timeUntilSponsor < skipBuffer && shouldAutoSkip(currentSkip)
         )
     ) {
         video.muted = false;
-        contentState.videoMuted = false;
+        videoMuted = false;
 
         for (const notice of contentState.skipNotices) {
             notice.unmutedListener(currentTime);
@@ -227,22 +273,22 @@ export async function startSponsorSchedule(
             const reportedVideoTimeAtStart = getVideo().currentTime;
             logDebug(`Starting setInterval skipping ${getVideo().currentTime} to skip at ${skipTime[0]}`);
 
-            if (contentState.currentSkipInterval !== null) clearInterval(contentState.currentSkipInterval);
-            contentState.currentSkipInterval = setInterval(() => {
+            if (currentSkipInterval !== null) clearInterval(currentSkipInterval);
+            currentSkipInterval = setInterval(() => {
                 if (
                     isFirefoxOrSafari() &&
-                    !contentState.lastKnownVideoTime.fromPause &&
+                    !lastKnownVideoTime.fromPause &&
                     startWaitingForReportedTimeToChange &&
                     reportedVideoTimeAtStart !== getVideo().currentTime
                 ) {
                     startWaitingForReportedTimeToChange = false;
                     const delay = getVirtualTime() - getVideo().currentTime;
-                    if (delay > 0) contentState.lastKnownVideoTime.approximateDelay = delay;
+                    if (delay > 0) lastKnownVideoTime.approximateDelay = delay;
                 }
 
                 const intervalDuration = performance.now() - startIntervalTime;
                 if (intervalDuration + skipBuffer * 1000 >= delayTime || getVideo().currentTime >= skipTime[0]) {
-                    clearInterval(contentState.currentSkipInterval);
+                    clearInterval(currentSkipInterval);
                     if (!isFirefoxOrSafari() && !getVideo().muted && !inMuteSegment(getVideo().currentTime, true)) {
                         getVideo().muted = true;
                         getVideo().muted = false;
@@ -261,7 +307,7 @@ export async function startSponsorSchedule(
 
             const offset = isFirefoxOrSafari() && !isSafari() ? 600 : 150;
             const offsetDelayTime = Math.max(0, delayTime - offset);
-            contentState.currentSkipSchedule = setTimeout(skippingFunction, offsetDelayTime);
+            currentSkipSchedule = setTimeout(skippingFunction, offsetDelayTime);
 
             if (
                 Config.config.advanceSkipNotice &&
@@ -276,8 +322,8 @@ export async function startSponsorSchedule(
                 const timeUntilPopup = Math.max(0, offsetDelayTime - maxPopupTime);
                 const autoSkip = shouldAutoSkip(skippingSegments[0]);
 
-                if (contentState.currentadvanceSkipSchedule) clearTimeout(contentState.currentadvanceSkipSchedule);
-                contentState.currentadvanceSkipSchedule = setTimeout(() => {
+                if (currentadvanceSkipSchedule) clearTimeout(currentadvanceSkipSchedule);
+                currentadvanceSkipSchedule = setTimeout(() => {
                     createAdvanceSkipNotice([skippingSegments[0]], skipTime[0], autoSkip, false);
                     sessionStorage.setItem("SKIPPING", "true");
                 }, timeUntilPopup);
@@ -298,10 +344,10 @@ function waitForNextTimeChange(): Promise<DOMHighResTimeStamp | null> {
 
 export function getVirtualTime(): number {
     const virtualTime =
-        contentState.lastTimeFromWaitingEvent ??
-        (contentState.lastKnownVideoTime.videoTime !== null
-            ? ((performance.now() - contentState.lastKnownVideoTime.preciseTime) * getVideo().playbackRate) / 1000 +
-            contentState.lastKnownVideoTime.videoTime
+        lastTimeFromWaitingEvent ??
+        (lastKnownVideoTime.videoTime !== null
+            ? ((performance.now() - lastKnownVideoTime.preciseTime) * getVideo().playbackRate) / 1000 +
+            lastKnownVideoTime.videoTime
             : null);
 
     if (
@@ -318,19 +364,19 @@ export function getVirtualTime(): number {
 }
 
 export function updateVirtualTime(): void {
-    if (contentState.currentVirtualTimeInterval) clearInterval(contentState.currentVirtualTimeInterval);
+    if (currentVirtualTimeInterval) clearInterval(currentVirtualTimeInterval);
 
-    contentState.lastKnownVideoTime.videoTime = getVideo().currentTime;
-    contentState.lastKnownVideoTime.preciseTime = performance.now();
+    lastKnownVideoTime.videoTime = getVideo().currentTime;
+    lastKnownVideoTime.preciseTime = performance.now();
 
     // If on Firefox, wait for the second time change (time remains fixed for many "frames" for privacy reasons)
     if (isFirefoxOrSafari()) {
         let count = 0;
         let rawCount = 0;
-        let lastTime = contentState.lastKnownVideoTime.videoTime;
+        let lastTime = lastKnownVideoTime.videoTime;
         let lastPerformanceTime = performance.now();
 
-        contentState.currentVirtualTimeInterval = setInterval(() => {
+        currentVirtualTimeInterval = setInterval(() => {
             const frameTime = performance.now() - lastPerformanceTime;
             if (lastTime !== getVideo().currentTime) {
                 rawCount++;
@@ -343,15 +389,15 @@ export function updateVirtualTime(): void {
 
             if (count > 1) {
                 const delay =
-                    contentState.lastKnownVideoTime.fromPause && contentState.lastKnownVideoTime.approximateDelay
-                        ? contentState.lastKnownVideoTime.approximateDelay
+                    lastKnownVideoTime.fromPause && lastKnownVideoTime.approximateDelay
+                        ? lastKnownVideoTime.approximateDelay
                         : 0;
 
-                contentState.lastKnownVideoTime.videoTime = getVideo().currentTime + delay;
-                contentState.lastKnownVideoTime.preciseTime = performance.now();
+                lastKnownVideoTime.videoTime = getVideo().currentTime + delay;
+                lastKnownVideoTime.preciseTime = performance.now();
 
-                clearInterval(contentState.currentVirtualTimeInterval);
-                contentState.currentVirtualTimeInterval = null;
+                clearInterval(currentVirtualTimeInterval);
+                currentVirtualTimeInterval = null;
             }
 
             lastPerformanceTime = performance.now();
@@ -360,11 +406,11 @@ export function updateVirtualTime(): void {
 }
 
 export function updateWaitingTime(): void {
-    contentState.lastTimeFromWaitingEvent = getVideo().currentTime;
+    lastTimeFromWaitingEvent = getVideo().currentTime;
 }
 
 export function clearWaitingTime(): void {
-    contentState.lastTimeFromWaitingEvent = null;
+    lastTimeFromWaitingEvent = null;
 }
 
 export function inMuteSegment(currentTime: number, includeOverlap: boolean): boolean {
@@ -635,8 +681,8 @@ function sendTelemetryAndCount(skippingSegments: SponsorTime[], secondsSkipped: 
     let counted = false;
     for (const segment of skippingSegments) {
         const index = contentState.sponsorTimes?.findIndex((s) => s.segment === segment.segment);
-        if (index !== -1 && !contentState.sponsorSkipped[index]) {
-            contentState.sponsorSkipped[index] = true;
+        if (index !== -1 && !sponsorSkipped[index]) {
+            sponsorSkipped[index] = true;
             if (!counted) {
                 Config.config.minutesSaved = Config.config.minutesSaved + secondsSkipped / 60;
                 Config.config.skipCount = Config.config.skipCount + 1;
@@ -710,8 +756,8 @@ export function startSkipScheduleCheckingForStartSponsors(): void {
 
         const fullVideoSegment = contentState.sponsorTimes.filter((time) => time.actionType === ActionType.Full)[0];
         if (fullVideoSegment) {
-            waitFor(() => contentState.categoryPill).then(() => {
-                contentState.categoryPill?.setSegment(fullVideoSegment);
+            waitFor(() => getCategoryPill()).then(() => {
+                getCategoryPill()?.setSegment(fullVideoSegment);
             });
         }
 
@@ -797,7 +843,7 @@ export function skipToTime({ v, skipTime, skippingSegments, openNotice, forceAut
                 } else {
                     if (inMuteSegment(skipTime[1], true)) {
                         v.muted = true;
-                        contentState.videoMuted = true;
+                        videoMuted = true;
                     }
 
                     v.currentTime = skipTime[1];
@@ -808,7 +854,7 @@ export function skipToTime({ v, skipTime, skippingSegments, openNotice, forceAut
             case ActionType.Mute: {
                 if (!v.muted) {
                     v.muted = true;
-                    contentState.videoMuted = true;
+                    videoMuted = true;
                 }
                 break;
             }
@@ -830,12 +876,12 @@ export function skipToTime({ v, skipTime, skippingSegments, openNotice, forceAut
     }
 
     if (!autoSkip && skippingSegments.length === 1 && skippingSegments[0].actionType === ActionType.Poi) {
-        waitFor(() => contentState.skipButtonControlBar).then(() => {
-            contentState.skipButtonControlBar.enable(skippingSegments[0]);
-            if (Config.config.skipKeybind == null) contentState.skipButtonControlBar.setShowKeybindHint(false);
+        waitFor(() => getSkipButtonControlBar()).then(() => {
+            getSkipButtonControlBar().enable(skippingSegments[0]);
+            if (Config.config.skipKeybind == null) getSkipButtonControlBar().setShowKeybindHint(false);
 
             contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
-            contentState.activeSkipKeybindElement = contentState.skipButtonControlBar;
+            contentState.activeSkipKeybindElement = getSkipButtonControlBar();
         });
     } else {
         if (openNotice) {
@@ -920,7 +966,7 @@ export function createAdvanceSkipNotice(
 export function unskipSponsorTime(segment: SponsorTime, unskipTime: number = null, forceSeek = false): void {
     if (segment.actionType === ActionType.Mute) {
         getVideo().muted = false;
-        contentState.videoMuted = false;
+        videoMuted = false;
     }
 
     if (forceSeek || segment.actionType === ActionType.Skip) {
@@ -931,7 +977,7 @@ export function unskipSponsorTime(segment: SponsorTime, unskipTime: number = nul
 export function reskipSponsorTime(segment: SponsorTime, forceSeek = false): void {
     if (segment.actionType === ActionType.Mute && !forceSeek) {
         getVideo().muted = true;
-        contentState.videoMuted = true;
+        videoMuted = true;
     } else {
         const skippedTime = Math.max(segment.segment[1] - getVideo().currentTime, 0);
         const segmentDuration = segment.segment[1] - segment.segment[0];

--- a/src/content/skipScheduler.ts
+++ b/src/content/skipScheduler.ts
@@ -41,7 +41,7 @@ const utils = new Utils();
 let currentSkipSchedule: NodeJS.Timeout = null;
 let currentSkipInterval: NodeJS.Timeout = null;
 let currentVirtualTimeInterval: NodeJS.Timeout = null;
-let currentadvanceSkipSchedule: NodeJS.Timeout = null;
+let currentAdvanceSkipSchedule: NodeJS.Timeout = null;
 let lastTimeFromWaitingEvent: number = null;
 let videoMuted = false;
 const lastKnownVideoTime: { videoTime: number; preciseTime: number; fromPause: boolean; approximateDelay: number } = {
@@ -69,9 +69,9 @@ export function resetSchedulerState(): void {
         clearInterval(currentVirtualTimeInterval);
         currentVirtualTimeInterval = null;
     }
-    if (currentadvanceSkipSchedule !== null) {
-        clearTimeout(currentadvanceSkipSchedule);
-        currentadvanceSkipSchedule = null;
+    if (currentAdvanceSkipSchedule !== null) {
+        clearTimeout(currentAdvanceSkipSchedule);
+        currentAdvanceSkipSchedule = null;
     }
     lastTimeFromWaitingEvent = null;
     videoMuted = false;
@@ -106,9 +106,9 @@ export function cancelSponsorSchedule(): void {
         currentSkipInterval = null;
     }
 
-    if (currentadvanceSkipSchedule !== null) {
-        clearInterval(currentadvanceSkipSchedule);
-        currentadvanceSkipSchedule = null;
+    if (currentAdvanceSkipSchedule !== null) {
+        clearInterval(currentAdvanceSkipSchedule);
+        currentAdvanceSkipSchedule = null;
     }
 }
 
@@ -322,8 +322,8 @@ export async function startSponsorSchedule(
                 const timeUntilPopup = Math.max(0, offsetDelayTime - maxPopupTime);
                 const autoSkip = shouldAutoSkip(skippingSegments[0]);
 
-                if (currentadvanceSkipSchedule) clearTimeout(currentadvanceSkipSchedule);
-                currentadvanceSkipSchedule = setTimeout(() => {
+                if (currentAdvanceSkipSchedule) clearTimeout(currentAdvanceSkipSchedule);
+                currentAdvanceSkipSchedule = setTimeout(() => {
                     createAdvanceSkipNotice([skippingSegments[0]], skipTime[0], autoSkip, false);
                     sessionStorage.setItem("SKIPPING", "true");
                 }, timeUntilPopup);

--- a/src/content/skipScheduler.ts
+++ b/src/content/skipScheduler.ts
@@ -1,0 +1,944 @@
+import Config from "../config";
+import { ContentContainer } from "../ContentContainerTypes";
+import advanceSkipNotice from "../render/advanceSkipNotice";
+import SkipNotice from "../render/SkipNotice";
+import { asyncRequestToServer } from "../requests/requests";
+import {
+    ActionType,
+    CategorySkipOption,
+    ChannelIDStatus,
+    ScheduledTime,
+    SkipToTimeParams,
+    SponsorHideType,
+    SponsorSourceType,
+    SponsorTime,
+} from "../types";
+import Utils from "../utils";
+import { isFirefox, isFirefoxOrSafari, isSafari, waitFor } from "../utils/";
+import { GenericUtils } from "../utils/genericUtils";
+import { logDebug } from "../utils/logger";
+import { isPlayingPlaylist } from "../utils/pageUtils";
+import { getBilibiliVideoID } from "../utils/parseVideoID";
+import { getStartTimeFromUrl } from "../utils/urlParser";
+import {
+    checkIfNewVideoID,
+    checkVideoIDChange,
+    getChannelIDInfo,
+    getVideo,
+    getVideoID,
+} from "../utils/video";
+import {
+    contentState,
+    endTimeSkipBuffer,
+    manualSkipPercentCount,
+    skipBuffer,
+} from "./state";
+
+const utils = new Utils();
+
+export interface SkipSchedulerDeps {
+    skipNoticeContentContainer: ContentContainer;
+    updateActiveSegment: (currentTime: number) => void;
+}
+
+let deps: SkipSchedulerDeps;
+
+export function initSkipScheduler(d: SkipSchedulerDeps): void {
+    deps = d;
+}
+
+export function cancelSponsorSchedule(): void {
+    logDebug("Pausing skipping");
+
+    if (contentState.currentSkipSchedule !== null) {
+        clearTimeout(contentState.currentSkipSchedule);
+        contentState.currentSkipSchedule = null;
+    }
+
+    if (contentState.currentSkipInterval !== null) {
+        clearInterval(contentState.currentSkipInterval);
+        contentState.currentSkipInterval = null;
+    }
+
+    if (contentState.currentadvanceSkipSchedule !== null) {
+        clearInterval(contentState.currentadvanceSkipSchedule);
+        contentState.currentadvanceSkipSchedule = null;
+    }
+}
+
+/**
+ * @param currentTime Optional if you don't want to use the actual current time
+ */
+export async function startSponsorSchedule(
+    includeIntersectingSegments = false,
+    currentTime?: number,
+    includeNonIntersectingSegments = true
+): Promise<void> {
+    cancelSponsorSchedule();
+
+    // Give up if video changed, and trigger a videoID change if so
+    if (await checkIfNewVideoID()) {
+        return;
+    }
+
+    const video = getVideo();
+    logDebug(`Considering to start skipping: ${!video}, ${video?.paused}`);
+    if (!video) return;
+    if (currentTime === undefined || currentTime === null) {
+        currentTime = getVirtualTime();
+    }
+    clearWaitingTime();
+
+    deps.updateActiveSegment(currentTime);
+
+    if (video.paused || (video.currentTime >= video.duration - 0.01 && video.duration > 1)) return;
+    const skipInfo = getNextSkipIndex(currentTime, includeIntersectingSegments, includeNonIntersectingSegments);
+
+    const currentSkip = skipInfo.array[skipInfo.index];
+    const skipTime: number[] = [currentSkip?.scheduledTime, skipInfo.array[skipInfo.endIndex]?.segment[1]];
+    const timeUntilSponsor = skipTime?.[0] - currentTime;
+    const videoID = getVideoID();
+
+    if (
+        contentState.videoMuted &&
+        !inMuteSegment(
+            currentTime,
+            skipInfo.index !== -1 && timeUntilSponsor < skipBuffer && shouldAutoSkip(currentSkip)
+        )
+    ) {
+        video.muted = false;
+        contentState.videoMuted = false;
+
+        for (const notice of contentState.skipNotices) {
+            notice.unmutedListener(currentTime);
+        }
+    }
+
+    logDebug(`Ready to start skipping: ${skipInfo.index} at ${currentTime}`);
+    if (skipInfo.index === -1) return;
+
+    if (
+        Config.config.disableSkipping ||
+        contentState.channelWhitelisted ||
+        (getChannelIDInfo().status === ChannelIDStatus.Fetching && Config.config.forceChannelCheck)
+    ) {
+        return;
+    }
+
+    if (await incorrectVideoCheck()) return;
+
+    // Find all indexes in between the start and end
+    let skippingSegments = [skipInfo.array[skipInfo.index]];
+    if (skipInfo.index !== skipInfo.endIndex) {
+        skippingSegments = [];
+
+        for (const segment of skipInfo.array) {
+            if (
+                shouldAutoSkip(segment) &&
+                segment.segment[0] >= skipTime[0] &&
+                segment.segment[1] <= skipTime[1] &&
+                segment.segment[0] === segment.scheduledTime
+            ) {
+                skippingSegments.push(segment);
+            }
+        }
+    }
+
+    logDebug(
+        `Next step in starting skipping: ${!shouldSkip(currentSkip)}, ${!contentState.sponsorTimesSubmitting?.some(
+            (segment) => segment.segment === currentSkip.segment
+        )}`
+    );
+
+    const skippingFunction = async (forceVideoTime?: number) => {
+        let forcedSkipTime: number = null;
+        let forcedIncludeIntersectingSegments = false;
+        let forcedIncludeNonIntersectingSegments = true;
+
+        if (await incorrectVideoCheck(videoID, currentSkip)) return;
+        forceVideoTime ||= Math.max(getVideo().currentTime, getVirtualTime());
+
+        if (
+            shouldSkip(currentSkip) ||
+            contentState.sponsorTimesSubmitting?.some((segment) => segment.segment === currentSkip.segment)
+        ) {
+            if (forceVideoTime >= skipTime[0] - skipBuffer && forceVideoTime < skipTime[1]) {
+                skipToTime({
+                    v: getVideo(),
+                    skipTime,
+                    skippingSegments,
+                    openNotice: skipInfo.openNotice,
+                });
+
+                for (const extra of skipInfo.extraIndexes) {
+                    const extraSkip = skipInfo.array[extra];
+                    if (shouldSkip(extraSkip)) {
+                        skipToTime({
+                            v: getVideo(),
+                            skipTime: [extraSkip.scheduledTime, extraSkip.segment[1]],
+                            skippingSegments: [extraSkip],
+                            openNotice: skipInfo.openNotice,
+                        });
+                    }
+                }
+
+                if (
+                    utils.getCategorySelection(currentSkip.category)?.option === CategorySkipOption.ManualSkip ||
+                    currentSkip.actionType === ActionType.Mute
+                ) {
+                    forcedSkipTime = skipTime[0] + 0.001;
+                } else {
+                    forcedSkipTime = skipTime[1];
+                    forcedIncludeNonIntersectingSegments = false;
+
+                    if (Math.abs(skipTime[1] - getVideo().duration) > endTimeSkipBuffer) {
+                        forcedIncludeIntersectingSegments = true;
+                    }
+                }
+            } else {
+                forcedSkipTime = forceVideoTime + 0.001;
+            }
+        } else {
+            forcedSkipTime = forceVideoTime + 0.001;
+        }
+
+        if (forcedSkipTime !== null && forceVideoTime > forcedSkipTime) {
+            forcedSkipTime = forceVideoTime;
+        }
+
+        startSponsorSchedule(forcedIncludeIntersectingSegments, forcedSkipTime, forcedIncludeNonIntersectingSegments);
+    };
+
+    if (timeUntilSponsor < skipBuffer) {
+        await skippingFunction(currentTime);
+    } else {
+        let delayTime = (timeUntilSponsor * 1000) / getVideo().playbackRate;
+        if (delayTime < (isFirefox() ? 750 : 300) && shouldAutoSkip(skippingSegments[0])) {
+            let forceStartIntervalTime: number | null = null;
+            if (isFirefox() && delayTime > 300) {
+                forceStartIntervalTime = await waitForNextTimeChange();
+            }
+
+            const startIntervalTime = forceStartIntervalTime || performance.now();
+            const startVideoTime = Math.max(currentTime, getVideo().currentTime);
+            delayTime = (skipTime?.[0] - startVideoTime) * 1000 * (1 / getVideo().playbackRate);
+
+            let startWaitingForReportedTimeToChange = true;
+            const reportedVideoTimeAtStart = getVideo().currentTime;
+            logDebug(`Starting setInterval skipping ${getVideo().currentTime} to skip at ${skipTime[0]}`);
+
+            if (contentState.currentSkipInterval !== null) clearInterval(contentState.currentSkipInterval);
+            contentState.currentSkipInterval = setInterval(() => {
+                if (
+                    isFirefoxOrSafari() &&
+                    !contentState.lastKnownVideoTime.fromPause &&
+                    startWaitingForReportedTimeToChange &&
+                    reportedVideoTimeAtStart !== getVideo().currentTime
+                ) {
+                    startWaitingForReportedTimeToChange = false;
+                    const delay = getVirtualTime() - getVideo().currentTime;
+                    if (delay > 0) contentState.lastKnownVideoTime.approximateDelay = delay;
+                }
+
+                const intervalDuration = performance.now() - startIntervalTime;
+                if (intervalDuration + skipBuffer * 1000 >= delayTime || getVideo().currentTime >= skipTime[0]) {
+                    clearInterval(contentState.currentSkipInterval);
+                    if (!isFirefoxOrSafari() && !getVideo().muted && !inMuteSegment(getVideo().currentTime, true)) {
+                        getVideo().muted = true;
+                        getVideo().muted = false;
+                    }
+
+                    skippingFunction(
+                        Math.max(
+                            getVideo().currentTime,
+                            startVideoTime + (getVideo().playbackRate * Math.max(delayTime, intervalDuration)) / 1000
+                        )
+                    );
+                }
+            }, 0);
+        } else {
+            logDebug(`Starting timeout to skip ${getVideo().currentTime} to skip at ${skipTime[0]}`);
+
+            const offset = isFirefoxOrSafari() && !isSafari() ? 600 : 150;
+            const offsetDelayTime = Math.max(0, delayTime - offset);
+            contentState.currentSkipSchedule = setTimeout(skippingFunction, offsetDelayTime);
+
+            if (
+                Config.config.advanceSkipNotice &&
+                Config.config.skipNoticeDurationBefore > 0 &&
+                getVideo().currentTime < skippingSegments[0].segment[0] &&
+                !contentState.sponsorTimesSubmitting?.some((segment) => segment.segment === currentSkip.segment) &&
+                [ActionType.Skip, ActionType.Mute].includes(skippingSegments[0].actionType) &&
+                shouldAutoSkip(skippingSegments[0]) &&
+                !getVideo()?.paused
+            ) {
+                const maxPopupTime = Config.config.skipNoticeDurationBefore * 1000;
+                const timeUntilPopup = Math.max(0, offsetDelayTime - maxPopupTime);
+                const autoSkip = shouldAutoSkip(skippingSegments[0]);
+
+                if (contentState.currentadvanceSkipSchedule) clearTimeout(contentState.currentadvanceSkipSchedule);
+                contentState.currentadvanceSkipSchedule = setTimeout(() => {
+                    createAdvanceSkipNotice([skippingSegments[0]], skipTime[0], autoSkip, false);
+                    sessionStorage.setItem("SKIPPING", "true");
+                }, timeUntilPopup);
+            }
+        }
+    }
+}
+
+/**
+ * Used on Firefox only, waits for the next animation frame until
+ * the video time has changed
+ */
+function waitForNextTimeChange(): Promise<DOMHighResTimeStamp | null> {
+    return new Promise((resolve) => {
+        getVideo().addEventListener("timeupdate", () => resolve(performance.now()), { once: true });
+    });
+}
+
+export function getVirtualTime(): number {
+    const virtualTime =
+        contentState.lastTimeFromWaitingEvent ??
+        (contentState.lastKnownVideoTime.videoTime !== null
+            ? ((performance.now() - contentState.lastKnownVideoTime.preciseTime) * getVideo().playbackRate) / 1000 +
+            contentState.lastKnownVideoTime.videoTime
+            : null);
+
+    if (
+        Config.config.useVirtualTime &&
+        !isSafari() &&
+        virtualTime &&
+        Math.abs(virtualTime - getVideo().currentTime) < 0.2 &&
+        getVideo().currentTime !== 0
+    ) {
+        return Math.max(virtualTime, getVideo().currentTime);
+    } else {
+        return getVideo().currentTime;
+    }
+}
+
+export function updateVirtualTime(): void {
+    if (contentState.currentVirtualTimeInterval) clearInterval(contentState.currentVirtualTimeInterval);
+
+    contentState.lastKnownVideoTime.videoTime = getVideo().currentTime;
+    contentState.lastKnownVideoTime.preciseTime = performance.now();
+
+    // If on Firefox, wait for the second time change (time remains fixed for many "frames" for privacy reasons)
+    if (isFirefoxOrSafari()) {
+        let count = 0;
+        let rawCount = 0;
+        let lastTime = contentState.lastKnownVideoTime.videoTime;
+        let lastPerformanceTime = performance.now();
+
+        contentState.currentVirtualTimeInterval = setInterval(() => {
+            const frameTime = performance.now() - lastPerformanceTime;
+            if (lastTime !== getVideo().currentTime) {
+                rawCount++;
+
+                if (frameTime < 20 || rawCount > 30) {
+                    count++;
+                }
+                lastTime = getVideo().currentTime;
+            }
+
+            if (count > 1) {
+                const delay =
+                    contentState.lastKnownVideoTime.fromPause && contentState.lastKnownVideoTime.approximateDelay
+                        ? contentState.lastKnownVideoTime.approximateDelay
+                        : 0;
+
+                contentState.lastKnownVideoTime.videoTime = getVideo().currentTime + delay;
+                contentState.lastKnownVideoTime.preciseTime = performance.now();
+
+                clearInterval(contentState.currentVirtualTimeInterval);
+                contentState.currentVirtualTimeInterval = null;
+            }
+
+            lastPerformanceTime = performance.now();
+        }, 1);
+    }
+}
+
+export function updateWaitingTime(): void {
+    contentState.lastTimeFromWaitingEvent = getVideo().currentTime;
+}
+
+export function clearWaitingTime(): void {
+    contentState.lastTimeFromWaitingEvent = null;
+}
+
+export function inMuteSegment(currentTime: number, includeOverlap: boolean): boolean {
+    const checkFunction = (segment) =>
+        segment.actionType === ActionType.Mute &&
+        segment.hidden === SponsorHideType.Visible &&
+        segment.segment[0] <= currentTime &&
+        (segment.segment[1] > currentTime || (includeOverlap && segment.segment[1] + 0.02 > currentTime));
+    return contentState.sponsorTimes?.some(checkFunction) || contentState.sponsorTimesSubmitting.some(checkFunction);
+}
+
+export function isSegmentMarkedNearCurrentTime(currentTime: number, range: number = 5): boolean {
+    const lowerBound = currentTime - range;
+    const upperBound = currentTime + range;
+
+    return contentState.sponsorTimes?.some((sponsorTime) => {
+        const {
+            segment: [startTime, endTime],
+        } = sponsorTime;
+        return startTime <= upperBound && endTime >= lowerBound;
+    });
+}
+
+/**
+ * This makes sure the videoID is still correct and if the sponsorTime is included
+ */
+export async function incorrectVideoCheck(videoID?: string, sponsorTime?: SponsorTime): Promise<boolean> {
+    const currentVideoID = await getBilibiliVideoID();
+    const recordedVideoID = videoID || getVideoID();
+    if (
+        currentVideoID !== recordedVideoID ||
+        (sponsorTime &&
+            (!contentState.sponsorTimes ||
+                !contentState.sponsorTimes?.some(
+                    (time) => time.segment[0] === sponsorTime.segment[0] && time.segment[1] === sponsorTime.segment[1]
+                )) &&
+            !contentState.sponsorTimesSubmitting.some(
+                (time) => time.segment[0] === sponsorTime.segment[0] && time.segment[1] === sponsorTime.segment[1]
+            ))
+    ) {
+        console.error("[SponsorBlock] The videoID recorded when trying to skip is different than what it should be.");
+        console.error("[SponsorBlock] VideoID recorded: " + recordedVideoID + ". Actual VideoID: " + currentVideoID);
+        console.error(
+            "[SponsorBlock] SponsorTime",
+            sponsorTime,
+            "sponsorTimes",
+            contentState.sponsorTimes,
+            "sponsorTimesSubmitting",
+            contentState.sponsorTimesSubmitting
+        );
+
+        checkVideoIDChange();
+
+        return true;
+    } else {
+        return false;
+    }
+}
+
+/**
+ * Returns info about the next upcoming sponsor skip
+ */
+function getNextSkipIndex(
+    currentTime: number,
+    includeIntersectingSegments: boolean,
+    includeNonIntersectingSegments: boolean
+): { array: ScheduledTime[]; index: number; endIndex: number; extraIndexes: number[]; openNotice: boolean } {
+    const autoSkipSorter = (segment: ScheduledTime) => {
+        const skipOption = utils.getCategorySelection(segment.category)?.option;
+        if (
+            (skipOption === CategorySkipOption.AutoSkip || shouldAutoSkip(segment)) &&
+            segment.actionType === ActionType.Skip
+        ) {
+            return 0;
+        } else if (skipOption !== CategorySkipOption.ShowOverlay) {
+            return 1;
+        } else {
+            return 2;
+        }
+    };
+
+    const { includedTimes: submittedArray, scheduledTimes: sponsorStartTimes } = getStartTimes(
+        contentState.sponsorTimes,
+        includeIntersectingSegments,
+        includeNonIntersectingSegments
+    );
+    const { scheduledTimes: sponsorStartTimesAfterCurrentTime } = getStartTimes(
+        contentState.sponsorTimes,
+        includeIntersectingSegments,
+        includeNonIntersectingSegments,
+        currentTime,
+        true
+    );
+
+    const minSponsorTimeIndexes = GenericUtils.indexesOf(
+        sponsorStartTimes,
+        Math.min(...sponsorStartTimesAfterCurrentTime)
+    );
+    const minSponsorTimeIndex =
+        minSponsorTimeIndexes.sort(
+            (a, b) =>
+                autoSkipSorter(submittedArray[a]) - autoSkipSorter(submittedArray[b]) ||
+                submittedArray[a].segment[1] -
+                submittedArray[a].segment[0] -
+                (submittedArray[b].segment[1] - submittedArray[b].segment[0])
+        )[0] ?? -1;
+    const extraIndexes = minSponsorTimeIndexes.filter(
+        (i) => i !== minSponsorTimeIndex && autoSkipSorter(submittedArray[i]) !== 0
+    );
+
+    const endTimeIndex = getLatestEndTimeIndex(submittedArray, minSponsorTimeIndex);
+
+    const { includedTimes: unsubmittedArray, scheduledTimes: unsubmittedSponsorStartTimes } = getStartTimes(
+        contentState.sponsorTimesSubmitting,
+        includeIntersectingSegments,
+        includeNonIntersectingSegments
+    );
+    const { scheduledTimes: unsubmittedSponsorStartTimesAfterCurrentTime } = getStartTimes(
+        contentState.sponsorTimesSubmitting,
+        includeIntersectingSegments,
+        includeNonIntersectingSegments,
+        currentTime,
+        false
+    );
+
+    const minUnsubmittedSponsorTimeIndex = unsubmittedSponsorStartTimes.indexOf(
+        Math.min(...unsubmittedSponsorStartTimesAfterCurrentTime)
+    );
+    const previewEndTimeIndex = getLatestEndTimeIndex(unsubmittedArray, minUnsubmittedSponsorTimeIndex);
+
+    if (
+        (minUnsubmittedSponsorTimeIndex === -1 && minSponsorTimeIndex !== -1) ||
+        sponsorStartTimes[minSponsorTimeIndex] < unsubmittedSponsorStartTimes[minUnsubmittedSponsorTimeIndex]
+    ) {
+        return {
+            array: submittedArray,
+            index: minSponsorTimeIndex,
+            endIndex: endTimeIndex,
+            extraIndexes,
+            openNotice: true,
+        };
+    } else {
+        return {
+            array: unsubmittedArray,
+            index: minUnsubmittedSponsorTimeIndex,
+            endIndex: previewEndTimeIndex,
+            extraIndexes: [],
+            openNotice: false,
+        };
+    }
+}
+
+/**
+ * This returns index if the skip option is not AutoSkip
+ *
+ * Finds the last endTime that occurs in a segment that the given
+ * segment skips into that is part of an AutoSkip category.
+ *
+ * Used to find where a segment should truely skip to if there are intersecting submissions due to
+ * them having different categories.
+ */
+function getLatestEndTimeIndex(sponsorTimes: SponsorTime[], index: number, hideHiddenSponsors = true): number {
+    if (index == -1 || !shouldAutoSkip(sponsorTimes[index]) || sponsorTimes[index].actionType !== ActionType.Skip) {
+        return index;
+    }
+
+    let latestEndTimeIndex = index;
+
+    for (let i = 0; i < sponsorTimes?.length; i++) {
+        const currentSegment = sponsorTimes[i].segment;
+        const latestEndTime = sponsorTimes[latestEndTimeIndex].segment[1];
+
+        if (
+            currentSegment[0] - skipBuffer <= latestEndTime &&
+            currentSegment[1] > latestEndTime &&
+            (!hideHiddenSponsors || sponsorTimes[i].hidden === SponsorHideType.Visible) &&
+            shouldAutoSkip(sponsorTimes[i]) &&
+            sponsorTimes[i].actionType === ActionType.Skip
+        ) {
+            latestEndTimeIndex = i;
+        }
+    }
+
+    if (latestEndTimeIndex !== index) {
+        latestEndTimeIndex = getLatestEndTimeIndex(sponsorTimes, latestEndTimeIndex, hideHiddenSponsors);
+    }
+
+    return latestEndTimeIndex;
+}
+
+/**
+ * Gets just the start times from a sponsor times array.
+ * Optionally specify a minimum
+ */
+function getStartTimes(
+    sponsorTimes: SponsorTime[],
+    includeIntersectingSegments: boolean,
+    includeNonIntersectingSegments: boolean,
+    minimum?: number,
+    hideHiddenSponsors = false
+): { includedTimes: ScheduledTime[]; scheduledTimes: number[] } {
+    if (!sponsorTimes) return { includedTimes: [], scheduledTimes: [] };
+
+    const includedTimes: ScheduledTime[] = [];
+    const scheduledTimes: number[] = [];
+
+    const shouldIncludeTime = (segment: ScheduledTime) =>
+        (minimum === undefined ||
+            (includeNonIntersectingSegments && segment.scheduledTime >= minimum) ||
+            (includeIntersectingSegments &&
+                segment.scheduledTime < minimum &&
+                segment.segment[1] > minimum &&
+                shouldSkip(segment))) &&
+        (!hideHiddenSponsors || segment.hidden === SponsorHideType.Visible) &&
+        segment.segment.length === 2 &&
+        segment.actionType !== ActionType.Poi &&
+        segment.actionType !== ActionType.Full;
+
+    const possibleTimes = sponsorTimes.map((sponsorTime) => ({
+        ...sponsorTime,
+        scheduledTime: sponsorTime.segment[0],
+    }));
+
+    sponsorTimes.forEach((sponsorTime) => {
+        if (
+            !possibleTimes.some((time) => sponsorTime.segment[1] === time.scheduledTime && shouldIncludeTime(time)) &&
+            (minimum === undefined || sponsorTime.segment[1] > minimum)
+        ) {
+            possibleTimes.push({
+                ...sponsorTime,
+                scheduledTime: sponsorTime.segment[1],
+            });
+        }
+    });
+
+    for (let i = 0; i < possibleTimes.length; i++) {
+        if (shouldIncludeTime(possibleTimes[i])) {
+            scheduledTimes.push(possibleTimes[i].scheduledTime);
+            includedTimes.push(possibleTimes[i]);
+        }
+    }
+
+    return { includedTimes, scheduledTimes };
+}
+
+export function previewTime(time: number, unpause = true): void {
+    contentState.previewedSegment = true;
+    getVideo().currentTime = time;
+
+    if (unpause && getVideo().paused) {
+        getVideo().play();
+    }
+}
+
+function sendTelemetryAndCount(skippingSegments: SponsorTime[], secondsSkipped: number, fullSkip: boolean): void {
+    for (const segment of skippingSegments) {
+        if (!contentState.previewedSegment && contentState.sponsorTimesSubmitting.some((s) => s.segment === segment.segment)) {
+            contentState.previewedSegment = true;
+        }
+    }
+
+    if (
+        !Config.config.trackViewCount ||
+        (!Config.config.trackViewCountInPrivate && chrome.extension.inIncognitoContext)
+    )
+        return;
+
+    let counted = false;
+    for (const segment of skippingSegments) {
+        const index = contentState.sponsorTimes?.findIndex((s) => s.segment === segment.segment);
+        if (index !== -1 && !contentState.sponsorSkipped[index]) {
+            contentState.sponsorSkipped[index] = true;
+            if (!counted) {
+                Config.config.minutesSaved = Config.config.minutesSaved + secondsSkipped / 60;
+                Config.config.skipCount = Config.config.skipCount + 1;
+                counted = true;
+            }
+
+            if (fullSkip) asyncRequestToServer("POST", "/api/viewedVideoSponsorTime?UUID=" + segment.UUID);
+        }
+    }
+}
+
+/**
+ * Only should be used when it is okay to skip a sponsor when in the middle of it
+ *
+ * Ex. When segments are first loaded
+ */
+export function startSkipScheduleCheckingForStartSponsors(): void {
+    // switchingVideos is ignored in Safari due to event fire order. See #1142
+    if ((!contentState.switchingVideos || isSafari()) && contentState.sponsorTimes) {
+        let startingSegmentTime = getStartTimeFromUrl(document.URL) || -1;
+        let found = false;
+        for (const time of contentState.sponsorTimes) {
+            if (
+                time.segment[0] <= getVideo().currentTime &&
+                time.segment[0] > startingSegmentTime &&
+                time.segment[1] > getVideo().currentTime &&
+                time.actionType !== ActionType.Poi
+            ) {
+                startingSegmentTime = time.segment[0];
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            for (const time of contentState.sponsorTimesSubmitting) {
+                if (
+                    time.segment[0] <= getVideo().currentTime &&
+                    time.segment[0] > startingSegmentTime &&
+                    time.segment[1] > getVideo().currentTime &&
+                    time.actionType !== ActionType.Poi
+                ) {
+                    startingSegmentTime = time.segment[0];
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        // For highlight category
+        const poiSegments = contentState.sponsorTimes
+            .filter(
+                (time) =>
+                    time.segment[1] > getVideo().currentTime &&
+                    time.actionType === ActionType.Poi &&
+                    time.hidden === SponsorHideType.Visible
+            )
+            .sort((a, b) => b.segment[0] - a.segment[0]);
+        for (const time of poiSegments) {
+            const skipOption = utils.getCategorySelection(time.category)?.option;
+            if (skipOption !== CategorySkipOption.ShowOverlay) {
+                skipToTime({
+                    v: getVideo(),
+                    skipTime: time.segment,
+                    skippingSegments: [time],
+                    openNotice: true,
+                    unskipTime: getVideo().currentTime,
+                });
+                if (skipOption === CategorySkipOption.AutoSkip) break;
+            }
+        }
+
+        const fullVideoSegment = contentState.sponsorTimes.filter((time) => time.actionType === ActionType.Full)[0];
+        if (fullVideoSegment) {
+            waitFor(() => contentState.categoryPill).then(() => {
+                contentState.categoryPill?.setSegment(fullVideoSegment);
+            });
+        }
+
+        if (startingSegmentTime !== -1) {
+            startSponsorSchedule(undefined, startingSegmentTime);
+        } else {
+            startSponsorSchedule();
+        }
+    }
+}
+
+export function shouldAutoSkip(segment: SponsorTime): boolean {
+    if (segment.source === SponsorSourceType.Danmaku) {
+        return Config.config.enableAutoSkipDanmakuSkip;
+    }
+    if (
+        Config.config.manualSkipOnFullVideo &&
+        contentState.sponsorTimes?.some((s) => s.category === segment.category && s.actionType === ActionType.Full)
+    ) {
+        return false;
+    }
+
+    const categoryOption = utils.getCategorySelection(segment.category)?.option;
+
+    if (categoryOption === CategorySkipOption.AutoSkip) {
+        return true;
+    } else if (
+        Config.config.autoSkipOnMusicVideos &&
+        contentState.sponsorTimes?.some((s) => s.category === "music_offtopic") &&
+        segment.actionType === ActionType.Skip
+    ) {
+        return true;
+    } else if (contentState.sponsorTimesSubmitting.some((s) => s.segment === segment.segment)) {
+        return true;
+    }
+
+    return false;
+}
+
+export function shouldSkip(segment: SponsorTime): boolean {
+    return (
+        (segment.actionType !== ActionType.Full &&
+            segment.source !== SponsorSourceType.YouTube &&
+            utils.getCategorySelection(segment.category)?.option !== CategorySkipOption.ShowOverlay) ||
+        (Config.config.autoSkipOnMusicVideos &&
+            contentState.sponsorTimes?.some((s) => s.category === "music_offtopic") &&
+            segment.actionType === ActionType.Skip)
+    );
+}
+
+export function skipToTime({ v, skipTime, skippingSegments, openNotice, forceAutoSkip, unskipTime }: SkipToTimeParams): void {
+    if (Config.config.disableSkipping) return;
+
+    let autoSkip: boolean;
+    if (sessionStorage.getItem("SKIPPING") === "false") {
+        sessionStorage.setItem("SKIPPING", "null");
+        autoSkip = false;
+    } else {
+        autoSkip = forceAutoSkip || shouldAutoSkip(skippingSegments[0]);
+    }
+
+    const isSubmittingSegment = contentState.sponsorTimesSubmitting.some((time) => time.segment === skippingSegments[0].segment);
+
+    if ((autoSkip || isSubmittingSegment) && v.currentTime !== skipTime[1]) {
+        switch (skippingSegments[0].actionType) {
+            case ActionType.Poi:
+            case ActionType.Skip: {
+                if (v.loop && v.duration > 1 && skipTime[1] >= v.duration - 1) {
+                    v.currentTime = 0;
+                } else if (
+                    v.duration > 1 &&
+                    skipTime[1] >= v.duration &&
+                    (navigator.vendor === "Apple Computer, Inc." || isPlayingPlaylist())
+                ) {
+                    v.currentTime = v.duration - 0.001;
+                } else if (
+                    v.duration > 1 &&
+                    Math.abs(skipTime[1] - v.duration) < endTimeSkipBuffer &&
+                    isFirefoxOrSafari() &&
+                    !isSafari()
+                ) {
+                    v.currentTime = v.duration;
+                } else {
+                    if (inMuteSegment(skipTime[1], true)) {
+                        v.muted = true;
+                        contentState.videoMuted = true;
+                    }
+
+                    v.currentTime = skipTime[1];
+                }
+
+                break;
+            }
+            case ActionType.Mute: {
+                if (!v.muted) {
+                    v.muted = true;
+                    contentState.videoMuted = true;
+                }
+                break;
+            }
+        }
+    }
+
+    if (autoSkip && Config.config.audioNotificationOnSkip && !isSubmittingSegment && !getVideo()?.muted) {
+        const beep = new Audio(chrome.runtime.getURL("icons/beep.ogg"));
+        beep.volume = getVideo().volume * 0.1;
+        const oldMetadata = navigator.mediaSession.metadata;
+        beep.play();
+        beep.addEventListener("ended", () => {
+            navigator.mediaSession.metadata = null;
+            setTimeout(() => {
+                navigator.mediaSession.metadata = oldMetadata;
+                beep.remove();
+            });
+        });
+    }
+
+    if (!autoSkip && skippingSegments.length === 1 && skippingSegments[0].actionType === ActionType.Poi) {
+        waitFor(() => contentState.skipButtonControlBar).then(() => {
+            contentState.skipButtonControlBar.enable(skippingSegments[0]);
+            if (Config.config.skipKeybind == null) contentState.skipButtonControlBar.setShowKeybindHint(false);
+
+            contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
+            contentState.activeSkipKeybindElement = contentState.skipButtonControlBar;
+        });
+    } else {
+        if (openNotice) {
+            if (!Config.config.dontShowNotice || !autoSkip) {
+                createSkipNotice(skippingSegments, autoSkip, unskipTime, false);
+            } else if (autoSkip) {
+                contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
+                contentState.activeSkipKeybindElement = {
+                    setShowKeybindHint: () => { },
+                    toggleSkip: () => {
+                        createSkipNotice(skippingSegments, autoSkip, unskipTime, true);
+
+                        unskipSponsorTime(skippingSegments[0], unskipTime);
+                    },
+                };
+            }
+        }
+    }
+
+    if (autoSkip || isSubmittingSegment) sendTelemetryAndCount(skippingSegments, skipTime[1] - skipTime[0], true);
+}
+
+export function createSkipNotice(
+    skippingSegments: SponsorTime[],
+    autoSkip: boolean,
+    unskipTime: number,
+    startReskip: boolean
+): void {
+    for (const skipNotice of contentState.skipNotices) {
+        if (
+            skippingSegments.length === skipNotice.segments.length &&
+            skippingSegments.every((segment) => skipNotice.segments.some((s) => s.UUID === segment.UUID))
+        ) {
+            return;
+        }
+    }
+
+    const advanceSkipNoticeShow = !!contentState.advanceSkipNotices;
+    const newSkipNotice = new SkipNotice(
+        skippingSegments,
+        autoSkip,
+        deps.skipNoticeContentContainer,
+        () => {
+            contentState.advanceSkipNotices?.close();
+            contentState.advanceSkipNotices = null;
+        },
+        unskipTime,
+        startReskip,
+        advanceSkipNoticeShow
+    );
+    if (Config.config.skipKeybind == null) newSkipNotice.setShowKeybindHint(false);
+    contentState.skipNotices.push(newSkipNotice);
+
+    contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
+    contentState.activeSkipKeybindElement = newSkipNotice;
+}
+
+export function createAdvanceSkipNotice(
+    skippingSegments: SponsorTime[],
+    unskipTime: number,
+    autoSkip: boolean,
+    startReskip: boolean
+): void {
+    if (contentState.advanceSkipNotices && !contentState.advanceSkipNotices.closed && contentState.advanceSkipNotices.sameNotice(skippingSegments)) {
+        return;
+    }
+
+    contentState.advanceSkipNotices?.close();
+    contentState.advanceSkipNotices = new advanceSkipNotice(
+        skippingSegments,
+        deps.skipNoticeContentContainer,
+        unskipTime,
+        autoSkip,
+        startReskip
+    );
+    if (Config.config.skipKeybind == null) contentState.advanceSkipNotices.setShowKeybindHint(false);
+
+    contentState.activeSkipKeybindElement?.setShowKeybindHint(false);
+    contentState.activeSkipKeybindElement = contentState.advanceSkipNotices;
+}
+
+export function unskipSponsorTime(segment: SponsorTime, unskipTime: number = null, forceSeek = false): void {
+    if (segment.actionType === ActionType.Mute) {
+        getVideo().muted = false;
+        contentState.videoMuted = false;
+    }
+
+    if (forceSeek || segment.actionType === ActionType.Skip) {
+        getVideo().currentTime = unskipTime ?? segment.segment[0] + 0.001;
+    }
+}
+
+export function reskipSponsorTime(segment: SponsorTime, forceSeek = false): void {
+    if (segment.actionType === ActionType.Mute && !forceSeek) {
+        getVideo().muted = true;
+        contentState.videoMuted = true;
+    } else {
+        const skippedTime = Math.max(segment.segment[1] - getVideo().currentTime, 0);
+        const segmentDuration = segment.segment[1] - segment.segment[0];
+        const fullSkip = skippedTime / segmentDuration > manualSkipPercentCount;
+
+        getVideo().currentTime = segment.segment[1];
+        sendTelemetryAndCount([segment], skippedTime, fullSkip);
+        startSponsorSchedule(true, segment.segment[1], false);
+    }
+}

--- a/src/content/state.ts
+++ b/src/content/state.ts
@@ -1,0 +1,233 @@
+import PreviewBar from "../js-components/previewBar";
+import { SkipButtonControlBar } from "../js-components/skipButtonControlBar";
+import advanceSkipNotice from "../render/advanceSkipNotice";
+import { CategoryPill } from "../render/CategoryPill";
+import { DescriptionPortPill } from "../render/DescriptionPortPill";
+import SkipNotice from "../render/SkipNotice";
+import SubmissionNotice from "../render/SubmissionNotice";
+import {
+    BVID,
+    Category,
+    PortVideo,
+    SegmentUUID,
+    SponsorTime,
+    ToggleSkippable,
+    VideoInfo,
+} from "../types";
+import { sourceId } from "../utils/injectedScriptMessageUtils";
+
+export const skipBuffer = 0.003;
+export const endTimeSkipBuffer = 0.5;
+export const manualSkipPercentCount = 0.5;
+
+let sponsorDataFound = false;
+let sponsorTimes: SponsorTime[] = [];
+const skipNotices: SkipNotice[] = [];
+let advanceSkipNoticesVar: advanceSkipNotice | null = null;
+let activeSkipKeybindElement: ToggleSkippable = null;
+let shownSegmentFailedToFetchWarning = false;
+let selectedSegment: SegmentUUID | null = null;
+let previewedSegment = false;
+
+let portVideo: PortVideo = null;
+
+let videoInfo: VideoInfo = null;
+let lockedCategories: Category[] = [];
+const lastKnownVideoTime: { videoTime: number; preciseTime: number; fromPause: boolean; approximateDelay: number } = {
+    videoTime: null,
+    preciseTime: null,
+    fromPause: false,
+    approximateDelay: null,
+};
+let lastTimeFromWaitingEvent: number = null;
+
+let currentSkipSchedule: NodeJS.Timeout = null;
+let currentSkipInterval: NodeJS.Timeout = null;
+let currentVirtualTimeInterval: NodeJS.Timeout = null;
+let currentadvanceSkipSchedule: NodeJS.Timeout = null;
+
+let sponsorSkipped: boolean[] = [];
+
+let videoMuted = false;
+
+let lastPreviewBarUpdate: BVID;
+let switchingVideos = null;
+let lastCheckTime = 0;
+let lastCheckVideoTime = -1;
+let channelWhitelisted = false;
+
+let previewBar: PreviewBar = null;
+let skipButtonControlBar: SkipButtonControlBar = null;
+let categoryPill: CategoryPill = null;
+let descriptionPill: DescriptionPortPill = null;
+let playerButtons: Record<string, { button: HTMLButtonElement; image: HTMLImageElement }> = {};
+
+let sponsorTimesSubmitting: SponsorTime[] = [];
+let loadedPreloadedSegment = false;
+
+let popupInitialised = false;
+
+let submissionNotice: SubmissionNotice = null;
+let lastResponseStatus: number;
+let lookupWaiting = false;
+
+let pageLoaded = false;
+
+/**
+ * Shared mutable state for content script modules.
+ *
+ * Instead of scattering module-level variables across content.ts,
+ * all state lives here so that extracted modules can import and
+ * share it without circular dependency issues.
+ */
+export const contentState = {
+    get sponsorDataFound() { return sponsorDataFound; },
+    set sponsorDataFound(v: boolean) { sponsorDataFound = v; },
+
+    get sponsorTimes() { return sponsorTimes; },
+    set sponsorTimes(v: SponsorTime[]) { sponsorTimes = v; },
+
+    get skipNotices() { return skipNotices; },
+
+    get advanceSkipNotices() { return advanceSkipNoticesVar; },
+    set advanceSkipNotices(v: advanceSkipNotice | null) { advanceSkipNoticesVar = v; },
+
+    get activeSkipKeybindElement() { return activeSkipKeybindElement; },
+    set activeSkipKeybindElement(v: ToggleSkippable) { activeSkipKeybindElement = v; },
+
+    get shownSegmentFailedToFetchWarning() { return shownSegmentFailedToFetchWarning; },
+    set shownSegmentFailedToFetchWarning(v: boolean) { shownSegmentFailedToFetchWarning = v; },
+
+    get selectedSegment() { return selectedSegment; },
+    set selectedSegment(v: SegmentUUID | null) { selectedSegment = v; },
+
+    get previewedSegment() { return previewedSegment; },
+    set previewedSegment(v: boolean) { previewedSegment = v; },
+
+    get portVideo() { return portVideo; },
+    set portVideo(v: PortVideo) { portVideo = v; },
+
+    get videoInfo() { return videoInfo; },
+    set videoInfo(v: VideoInfo) { videoInfo = v; },
+
+    get lockedCategories() { return lockedCategories; },
+    set lockedCategories(v: Category[]) { lockedCategories = v; },
+
+    get lastKnownVideoTime() { return lastKnownVideoTime; },
+
+    get lastTimeFromWaitingEvent() { return lastTimeFromWaitingEvent; },
+    set lastTimeFromWaitingEvent(v: number) { lastTimeFromWaitingEvent = v; },
+
+    get currentSkipSchedule() { return currentSkipSchedule; },
+    set currentSkipSchedule(v: NodeJS.Timeout) { currentSkipSchedule = v; },
+
+    get currentSkipInterval() { return currentSkipInterval; },
+    set currentSkipInterval(v: NodeJS.Timeout) { currentSkipInterval = v; },
+
+    get currentVirtualTimeInterval() { return currentVirtualTimeInterval; },
+    set currentVirtualTimeInterval(v: NodeJS.Timeout) { currentVirtualTimeInterval = v; },
+
+    get currentadvanceSkipSchedule() { return currentadvanceSkipSchedule; },
+    set currentadvanceSkipSchedule(v: NodeJS.Timeout) { currentadvanceSkipSchedule = v; },
+
+    get sponsorSkipped() { return sponsorSkipped; },
+    set sponsorSkipped(v: boolean[]) { sponsorSkipped = v; },
+
+    get videoMuted() { return videoMuted; },
+    set videoMuted(v: boolean) { videoMuted = v; },
+
+    get lastPreviewBarUpdate() { return lastPreviewBarUpdate; },
+    set lastPreviewBarUpdate(v: BVID) { lastPreviewBarUpdate = v; },
+
+    get switchingVideos() { return switchingVideos; },
+    set switchingVideos(v) { switchingVideos = v; },
+
+    get lastCheckTime() { return lastCheckTime; },
+    set lastCheckTime(v: number) { lastCheckTime = v; },
+
+    get lastCheckVideoTime() { return lastCheckVideoTime; },
+    set lastCheckVideoTime(v: number) { lastCheckVideoTime = v; },
+
+    get channelWhitelisted() { return channelWhitelisted; },
+    set channelWhitelisted(v: boolean) { channelWhitelisted = v; },
+
+    get previewBar() { return previewBar; },
+    set previewBar(v: PreviewBar) { previewBar = v; },
+
+    get skipButtonControlBar() { return skipButtonControlBar; },
+    set skipButtonControlBar(v: SkipButtonControlBar) { skipButtonControlBar = v; },
+
+    get categoryPill() { return categoryPill; },
+    set categoryPill(v: CategoryPill) { categoryPill = v; },
+
+    get descriptionPill() { return descriptionPill; },
+    set descriptionPill(v: DescriptionPortPill) { descriptionPill = v; },
+
+    get playerButtons() { return playerButtons; },
+    set playerButtons(v: Record<string, { button: HTMLButtonElement; image: HTMLImageElement }>) { playerButtons = v; },
+
+    get sponsorTimesSubmitting() { return sponsorTimesSubmitting; },
+    set sponsorTimesSubmitting(v: SponsorTime[]) { sponsorTimesSubmitting = v; },
+
+    get loadedPreloadedSegment() { return loadedPreloadedSegment; },
+    set loadedPreloadedSegment(v: boolean) { loadedPreloadedSegment = v; },
+
+    get popupInitialised() { return popupInitialised; },
+    set popupInitialised(v: boolean) { popupInitialised = v; },
+
+    get submissionNotice() { return submissionNotice; },
+    set submissionNotice(v: SubmissionNotice) { submissionNotice = v; },
+
+    get lastResponseStatus() { return lastResponseStatus; },
+    set lastResponseStatus(v: number) { lastResponseStatus = v; },
+
+    get lookupWaiting() { return lookupWaiting; },
+    set lookupWaiting(v: boolean) { lookupWaiting = v; },
+
+    get pageLoaded() { return pageLoaded; },
+    set pageLoaded(v: boolean) { pageLoaded = v; },
+};
+
+/**
+ * Wait for the page to be truly available (Vue mount / hydration completed)
+ * before allowing the plugin to operate on the DOM.
+ *
+ * Primary: Listen for "pageReady" messages from MAIN world.
+ * Fallback: If no message is received within 30 s, use readyState=complete + 2 s delay.
+ */
+export function setupPageLoadingListener(): void {
+    const TAG = "[BSB-pageReady]";
+    const t0 = performance.now();
+
+    let resolved = false;
+    const markReady = (reason: string) => {
+        if (resolved) return;
+        resolved = true;
+        const elapsed = Math.round(performance.now() - t0);
+        console.debug(`${TAG} Page ready (${reason}) at +${elapsed}ms`);
+        contentState.pageLoaded = true;
+    };
+
+    window.addEventListener("message", (e: MessageEvent) => {
+        if (e.data?.source === sourceId && e.data?.type === "pageReady") {
+            markReady("vue-mount signal from MAIN world");
+        }
+    });
+
+    const FALLBACK_TIMEOUT = 30000;
+    setTimeout(() => {
+        if (!resolved) {
+            if (document.readyState === "complete") {
+                markReady(`fallback: readyState already complete after ${FALLBACK_TIMEOUT}ms`);
+            } else {
+                window.addEventListener("load", () => {
+                    setTimeout(() => markReady("fallback: window.load + 2s delay"), 2000);
+                }, { once: true });
+            }
+        }
+    }, FALLBACK_TIMEOUT);
+}
+
+export function getPageLoaded(): boolean {
+    return contentState.pageLoaded;
+}

--- a/src/content/state.ts
+++ b/src/content/state.ts
@@ -1,15 +1,8 @@
-import PreviewBar from "../js-components/previewBar";
-import { SkipButtonControlBar } from "../js-components/skipButtonControlBar";
 import advanceSkipNotice from "../render/advanceSkipNotice";
-import { CategoryPill } from "../render/CategoryPill";
-import { DescriptionPortPill } from "../render/DescriptionPortPill";
 import SkipNotice from "../render/SkipNotice";
-import SubmissionNotice from "../render/SubmissionNotice";
 import {
-    BVID,
     Category,
     PortVideo,
-    SegmentUUID,
     SponsorTime,
     ToggleSkippable,
     VideoInfo,
@@ -26,50 +19,19 @@ const skipNotices: SkipNotice[] = [];
 let advanceSkipNoticesVar: advanceSkipNotice | null = null;
 let activeSkipKeybindElement: ToggleSkippable = null;
 let shownSegmentFailedToFetchWarning = false;
-let selectedSegment: SegmentUUID | null = null;
 let previewedSegment = false;
 
 let portVideo: PortVideo = null;
 
 let videoInfo: VideoInfo = null;
 let lockedCategories: Category[] = [];
-const lastKnownVideoTime: { videoTime: number; preciseTime: number; fromPause: boolean; approximateDelay: number } = {
-    videoTime: null,
-    preciseTime: null,
-    fromPause: false,
-    approximateDelay: null,
-};
-let lastTimeFromWaitingEvent: number = null;
 
-let currentSkipSchedule: NodeJS.Timeout = null;
-let currentSkipInterval: NodeJS.Timeout = null;
-let currentVirtualTimeInterval: NodeJS.Timeout = null;
-let currentadvanceSkipSchedule: NodeJS.Timeout = null;
-
-let sponsorSkipped: boolean[] = [];
-
-let videoMuted = false;
-
-let lastPreviewBarUpdate: BVID;
 let switchingVideos = null;
-let lastCheckTime = 0;
-let lastCheckVideoTime = -1;
 let channelWhitelisted = false;
 
-let previewBar: PreviewBar = null;
-let skipButtonControlBar: SkipButtonControlBar = null;
-let categoryPill: CategoryPill = null;
-let descriptionPill: DescriptionPortPill = null;
-let playerButtons: Record<string, { button: HTMLButtonElement; image: HTMLImageElement }> = {};
-
 let sponsorTimesSubmitting: SponsorTime[] = [];
-let loadedPreloadedSegment = false;
 
-let popupInitialised = false;
-
-let submissionNotice: SubmissionNotice = null;
 let lastResponseStatus: number;
-let lookupWaiting = false;
 
 let pageLoaded = false;
 
@@ -98,9 +60,6 @@ export const contentState = {
     get shownSegmentFailedToFetchWarning() { return shownSegmentFailedToFetchWarning; },
     set shownSegmentFailedToFetchWarning(v: boolean) { shownSegmentFailedToFetchWarning = v; },
 
-    get selectedSegment() { return selectedSegment; },
-    set selectedSegment(v: SegmentUUID | null) { selectedSegment = v; },
-
     get previewedSegment() { return previewedSegment; },
     set previewedSegment(v: boolean) { previewedSegment = v; },
 
@@ -113,76 +72,17 @@ export const contentState = {
     get lockedCategories() { return lockedCategories; },
     set lockedCategories(v: Category[]) { lockedCategories = v; },
 
-    get lastKnownVideoTime() { return lastKnownVideoTime; },
-
-    get lastTimeFromWaitingEvent() { return lastTimeFromWaitingEvent; },
-    set lastTimeFromWaitingEvent(v: number) { lastTimeFromWaitingEvent = v; },
-
-    get currentSkipSchedule() { return currentSkipSchedule; },
-    set currentSkipSchedule(v: NodeJS.Timeout) { currentSkipSchedule = v; },
-
-    get currentSkipInterval() { return currentSkipInterval; },
-    set currentSkipInterval(v: NodeJS.Timeout) { currentSkipInterval = v; },
-
-    get currentVirtualTimeInterval() { return currentVirtualTimeInterval; },
-    set currentVirtualTimeInterval(v: NodeJS.Timeout) { currentVirtualTimeInterval = v; },
-
-    get currentadvanceSkipSchedule() { return currentadvanceSkipSchedule; },
-    set currentadvanceSkipSchedule(v: NodeJS.Timeout) { currentadvanceSkipSchedule = v; },
-
-    get sponsorSkipped() { return sponsorSkipped; },
-    set sponsorSkipped(v: boolean[]) { sponsorSkipped = v; },
-
-    get videoMuted() { return videoMuted; },
-    set videoMuted(v: boolean) { videoMuted = v; },
-
-    get lastPreviewBarUpdate() { return lastPreviewBarUpdate; },
-    set lastPreviewBarUpdate(v: BVID) { lastPreviewBarUpdate = v; },
-
     get switchingVideos() { return switchingVideos; },
     set switchingVideos(v) { switchingVideos = v; },
-
-    get lastCheckTime() { return lastCheckTime; },
-    set lastCheckTime(v: number) { lastCheckTime = v; },
-
-    get lastCheckVideoTime() { return lastCheckVideoTime; },
-    set lastCheckVideoTime(v: number) { lastCheckVideoTime = v; },
 
     get channelWhitelisted() { return channelWhitelisted; },
     set channelWhitelisted(v: boolean) { channelWhitelisted = v; },
 
-    get previewBar() { return previewBar; },
-    set previewBar(v: PreviewBar) { previewBar = v; },
-
-    get skipButtonControlBar() { return skipButtonControlBar; },
-    set skipButtonControlBar(v: SkipButtonControlBar) { skipButtonControlBar = v; },
-
-    get categoryPill() { return categoryPill; },
-    set categoryPill(v: CategoryPill) { categoryPill = v; },
-
-    get descriptionPill() { return descriptionPill; },
-    set descriptionPill(v: DescriptionPortPill) { descriptionPill = v; },
-
-    get playerButtons() { return playerButtons; },
-    set playerButtons(v: Record<string, { button: HTMLButtonElement; image: HTMLImageElement }>) { playerButtons = v; },
-
     get sponsorTimesSubmitting() { return sponsorTimesSubmitting; },
     set sponsorTimesSubmitting(v: SponsorTime[]) { sponsorTimesSubmitting = v; },
 
-    get loadedPreloadedSegment() { return loadedPreloadedSegment; },
-    set loadedPreloadedSegment(v: boolean) { loadedPreloadedSegment = v; },
-
-    get popupInitialised() { return popupInitialised; },
-    set popupInitialised(v: boolean) { popupInitialised = v; },
-
-    get submissionNotice() { return submissionNotice; },
-    set submissionNotice(v: SubmissionNotice) { submissionNotice = v; },
-
     get lastResponseStatus() { return lastResponseStatus; },
     set lastResponseStatus(v: number) { lastResponseStatus = v; },
-
-    get lookupWaiting() { return lookupWaiting; },
-    set lookupWaiting(v: boolean) { lookupWaiting = v; },
 
     get pageLoaded() { return pageLoaded; },
     set pageLoaded(v: boolean) { pageLoaded = v; },

--- a/src/content/videoListeners.ts
+++ b/src/content/videoListeners.ts
@@ -1,0 +1,224 @@
+import Config from "../config";
+import { addCleanupListener } from "../utils/cleanup";
+import { logDebug } from "../utils/logger";
+import { getVideoID } from "../utils/video";
+import { danmakuForSkip } from "./danmakuSkip";
+import { createPreviewBar, updateActiveSegment, updatePreviewBar } from "./previewBarManager";
+import {
+    cancelSponsorSchedule,
+    clearWaitingTime,
+    startSkipScheduleCheckingForStartSponsors,
+    startSponsorSchedule,
+    updateVirtualTime,
+    updateWaitingTime,
+} from "./skipScheduler";
+import { contentState } from "./state";
+
+export interface VideoListenerDeps {
+    updateVisibilityOfPlayerControlsButton: () => Promise<void>;
+}
+
+let deps: VideoListenerDeps;
+
+export function initVideoListeners(d: VideoListenerDeps): void {
+    deps = d;
+}
+
+let playbackRateCheckInterval: NodeJS.Timeout | null = null;
+let lastPlaybackSpeed = 1;
+let setupVideoListenersFirstTime = true;
+
+/**
+ * Triggered every time the video duration changes.
+ * This happens when the resolution changes or at random time to clear memory.
+ */
+export function durationChangeListener(): void {
+    updatePreviewBar();
+}
+
+/**
+ * Triggered once the video is ready.
+ * This is mainly to attach to embedded players who don't have a video element visible.
+ */
+export function videoOnReadyListener(): void {
+    createPreviewBar();
+    updatePreviewBar();
+    deps.updateVisibilityOfPlayerControlsButton();
+}
+
+export function setupVideoListeners(video: HTMLVideoElement): void {
+    if (!video) return;
+
+    video.addEventListener("loadstart", videoOnReadyListener);
+    video.addEventListener("durationchange", durationChangeListener);
+
+    if (setupVideoListenersFirstTime) {
+        addCleanupListener(() => {
+            video.removeEventListener("loadstart", videoOnReadyListener);
+            video.removeEventListener("durationchange", durationChangeListener);
+        });
+    }
+
+    if (!Config.config.disableSkipping) {
+        danmakuForSkip();
+
+        contentState.switchingVideos = false;
+
+        let startedWaiting = false;
+        let lastPausedAtZero = true;
+
+        const rateChangeListener = () => {
+            updateVirtualTime();
+            clearWaitingTime();
+
+            startSponsorSchedule();
+        };
+        video.addEventListener("ratechange", rateChangeListener);
+        video.addEventListener("videoSpeed_ratechange", rateChangeListener);
+
+        const playListener = () => {
+            if (video.readyState <= HTMLMediaElement.HAVE_CURRENT_DATA && video.currentTime === 0) return;
+
+            updateVirtualTime();
+
+            if (contentState.switchingVideos || lastPausedAtZero) {
+                contentState.switchingVideos = false;
+                logDebug("Setting switching videos to false");
+
+                if (contentState.sponsorTimes) startSkipScheduleCheckingForStartSponsors();
+            }
+
+            lastPausedAtZero = false;
+
+            if (
+                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
+                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
+            ) {
+                contentState.lastCheckTime = Date.now();
+                contentState.lastCheckVideoTime = video.currentTime;
+
+                startSponsorSchedule();
+            }
+        };
+        video.addEventListener("play", playListener);
+
+        const playingListener = () => {
+            updateVirtualTime();
+            lastPausedAtZero = false;
+
+            if (startedWaiting) {
+                startedWaiting = false;
+                logDebug(
+                    `[SB] Playing event after buffering: ${Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
+                    (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
+                    }`
+                );
+            }
+
+            if (contentState.switchingVideos) {
+                contentState.switchingVideos = false;
+                logDebug("Setting switching videos to false");
+
+                if (contentState.sponsorTimes) startSkipScheduleCheckingForStartSponsors();
+            }
+
+            if (
+                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
+                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
+            ) {
+                contentState.lastCheckTime = Date.now();
+                contentState.lastCheckVideoTime = video.currentTime;
+
+                startSponsorSchedule();
+            }
+
+            if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
+            lastPlaybackSpeed = video.playbackRate;
+
+            if (document.body.classList.contains("vsc-initialized")) {
+                playbackRateCheckInterval = setInterval(() => {
+                    if ((!getVideoID() || video.paused) && playbackRateCheckInterval) {
+                        clearInterval(playbackRateCheckInterval);
+                        return;
+                    }
+
+                    if (video.playbackRate !== lastPlaybackSpeed) {
+                        lastPlaybackSpeed = video.playbackRate;
+
+                        rateChangeListener();
+                    }
+                }, 2000);
+            }
+        };
+        video.addEventListener("playing", playingListener);
+
+        const seekingListener = () => {
+            contentState.lastKnownVideoTime.fromPause = false;
+
+            if (!video.paused) {
+                contentState.lastCheckTime = Date.now();
+                contentState.lastCheckVideoTime = video.currentTime;
+
+                updateVirtualTime();
+                clearWaitingTime();
+
+                if (video.loop && video.currentTime < 0.2) {
+                    startSponsorSchedule(false, 0);
+                } else {
+                    startSponsorSchedule(Config.config.skipOnSeekToSegment);
+                }
+            } else {
+                updateActiveSegment(video.currentTime);
+
+                if (video.currentTime === 0) {
+                    lastPausedAtZero = true;
+                }
+            }
+        };
+        video.addEventListener("seeking", seekingListener);
+
+        const stoppedPlayback = () => {
+            contentState.lastCheckVideoTime = -1;
+            contentState.lastCheckTime = 0;
+
+            if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
+
+            contentState.lastKnownVideoTime.videoTime = null;
+            contentState.lastKnownVideoTime.preciseTime = null;
+            updateWaitingTime();
+
+            cancelSponsorSchedule();
+        };
+        const pauseListener = () => {
+            contentState.lastKnownVideoTime.fromPause = true;
+
+            stoppedPlayback();
+        };
+        video.addEventListener("pause", pauseListener);
+        const waitingListener = () => {
+            logDebug("[SB] Not skipping due to buffering");
+            startedWaiting = true;
+
+            stoppedPlayback();
+        };
+        video.addEventListener("waiting", waitingListener);
+
+        startSponsorSchedule();
+
+        if (setupVideoListenersFirstTime) {
+            addCleanupListener(() => {
+                video.removeEventListener("play", playListener);
+                video.removeEventListener("playing", playingListener);
+                video.removeEventListener("seeking", seekingListener);
+                video.removeEventListener("ratechange", rateChangeListener);
+                video.removeEventListener("videoSpeed_ratechange", rateChangeListener);
+                video.removeEventListener("pause", pauseListener);
+                video.removeEventListener("waiting", waitingListener);
+
+                if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
+            });
+        }
+    }
+
+    setupVideoListenersFirstTime = false;
+}

--- a/src/content/videoListeners.ts
+++ b/src/content/videoListeners.ts
@@ -7,12 +7,22 @@ import { createPreviewBar, updateActiveSegment, updatePreviewBar } from "./previ
 import {
     cancelSponsorSchedule,
     clearWaitingTime,
+    getLastKnownVideoTime,
     startSkipScheduleCheckingForStartSponsors,
     startSponsorSchedule,
     updateVirtualTime,
     updateWaitingTime,
 } from "./skipScheduler";
 import { contentState } from "./state";
+
+// --- Module-private state (formerly on contentState) ---
+let lastCheckTime = 0;
+let lastCheckVideoTime = -1;
+
+export function resetVideoListenerState(): void {
+    lastCheckTime = 0;
+    lastCheckVideoTime = -1;
+}
 
 export interface VideoListenerDeps {
     updateVisibilityOfPlayerControlsButton: () => Promise<void>;
@@ -91,11 +101,11 @@ export function setupVideoListeners(video: HTMLVideoElement): void {
             lastPausedAtZero = false;
 
             if (
-                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
-                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
+                Math.abs(lastCheckVideoTime - video.currentTime) > 0.3 ||
+                (lastCheckVideoTime !== video.currentTime && Date.now() - lastCheckTime > 2000)
             ) {
-                contentState.lastCheckTime = Date.now();
-                contentState.lastCheckVideoTime = video.currentTime;
+                lastCheckTime = Date.now();
+                lastCheckVideoTime = video.currentTime;
 
                 startSponsorSchedule();
             }
@@ -109,8 +119,8 @@ export function setupVideoListeners(video: HTMLVideoElement): void {
             if (startedWaiting) {
                 startedWaiting = false;
                 logDebug(
-                    `[SB] Playing event after buffering: ${Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
-                    (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
+                    `[SB] Playing event after buffering: ${Math.abs(lastCheckVideoTime - video.currentTime) > 0.3 ||
+                    (lastCheckVideoTime !== video.currentTime && Date.now() - lastCheckTime > 2000)
                     }`
                 );
             }
@@ -123,11 +133,11 @@ export function setupVideoListeners(video: HTMLVideoElement): void {
             }
 
             if (
-                Math.abs(contentState.lastCheckVideoTime - video.currentTime) > 0.3 ||
-                (contentState.lastCheckVideoTime !== video.currentTime && Date.now() - contentState.lastCheckTime > 2000)
+                Math.abs(lastCheckVideoTime - video.currentTime) > 0.3 ||
+                (lastCheckVideoTime !== video.currentTime && Date.now() - lastCheckTime > 2000)
             ) {
-                contentState.lastCheckTime = Date.now();
-                contentState.lastCheckVideoTime = video.currentTime;
+                lastCheckTime = Date.now();
+                lastCheckVideoTime = video.currentTime;
 
                 startSponsorSchedule();
             }
@@ -153,11 +163,11 @@ export function setupVideoListeners(video: HTMLVideoElement): void {
         video.addEventListener("playing", playingListener);
 
         const seekingListener = () => {
-            contentState.lastKnownVideoTime.fromPause = false;
+            getLastKnownVideoTime().fromPause = false;
 
             if (!video.paused) {
-                contentState.lastCheckTime = Date.now();
-                contentState.lastCheckVideoTime = video.currentTime;
+                lastCheckTime = Date.now();
+                lastCheckVideoTime = video.currentTime;
 
                 updateVirtualTime();
                 clearWaitingTime();
@@ -178,19 +188,19 @@ export function setupVideoListeners(video: HTMLVideoElement): void {
         video.addEventListener("seeking", seekingListener);
 
         const stoppedPlayback = () => {
-            contentState.lastCheckVideoTime = -1;
-            contentState.lastCheckTime = 0;
+            lastCheckVideoTime = -1;
+            lastCheckTime = 0;
 
             if (playbackRateCheckInterval) clearInterval(playbackRateCheckInterval);
 
-            contentState.lastKnownVideoTime.videoTime = null;
-            contentState.lastKnownVideoTime.preciseTime = null;
+            getLastKnownVideoTime().videoTime = null;
+            getLastKnownVideoTime().preciseTime = null;
             updateWaitingTime();
 
             cancelSponsorSchedule();
         };
         const pauseListener = () => {
-            contentState.lastKnownVideoTime.fromPause = true;
+            getLastKnownVideoTime().fromPause = true;
 
             stoppedPlayback();
         };

--- a/src/js-components/skipButtonControlBar.ts
+++ b/src/js-components/skipButtonControlBar.ts
@@ -1,6 +1,6 @@
 import Config from "../config";
 import { keybindToString } from "../config/config";
-import { getPageLoaded } from "../content";
+import { getPageLoaded } from "../content/state";
 import { SegmentUUID, SponsorTime } from "../types";
 import { AnimationUtils } from "../utils/animationUtils";
 import { getSkippingText } from "../utils/categoryUtils";

--- a/src/thumbnail-utils/thumbnailManagement.ts
+++ b/src/thumbnail-utils/thumbnailManagement.ts
@@ -1,5 +1,5 @@
 import Config from "../config";
-import { getPageLoaded } from "../content";
+import { getPageLoaded } from "../content/state";
 import { PageType } from "../types";
 import { waitFor } from "../utils/";
 import { addCleanupListener } from "../utils/cleanup";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- [x] 我同意我的所有贡献将以GPL-3.0协议开源。

***

## 概述

将 `src/content.ts`（原 ~2957 行）拆分为 8 个职责单一的子模块 + 一个共享状态模块，主入口精简到 ~350 行的协调层。随后对共享状态进行私有化，将 22 个字段从全局 `contentState` 下沉到各自归属的模块中。

## 拆分结构

| 模块 | 行数 | 职责 |
|------|------|------|
| `content/state.ts` | 134 | 跨模块共享状态（15 个字段）+ 页面加载检测 |
| `content/danmakuSkip.ts` | 112 | 弹幕跳过检测与触发 |
| `content/hotkeyHandler.ts` | 130 | 快捷键监听与处理 |
| `content/messageHandler.ts` | 270 | chrome.runtime 消息 + 配置变更监听 |
| `content/previewBarManager.ts` | 169 | 进度条预览管理 |
| `content/skipScheduler.ts` | 944 | 跳过调度引擎（核心） |
| `content/videoListeners.ts` | 224 | 视频事件监听 |
| `content/segmentSubmission.ts` | 772 | 片段创建/提交/投票/UI |
| `content.ts` (主入口) | 352 | 初始化序列 + 模块协调 |

## 状态私有化

将 22 个 `contentState` 字段下沉到各自的归属模块，仅通过 getter 函数暴露必要的只读访问：

| 目标模块 | 私有化的字段 | 对外暴露 |
|---------|------------|---------|
| `skipScheduler` | 4 个 timer + `videoMuted` + `lastTimeFromWaitingEvent` + `lastKnownVideoTime` + `sponsorSkipped` | `getLastKnownVideoTime()`, `getSponsorSkipped()`, `resetSponsorSkipped()` |
| `previewBarManager` | `previewBar`, `selectedSegment`, `lastPreviewBarUpdate` | `getPreviewBar()`, `resetPreviewBarState()` |
| `segmentSubmission` | `skipButtonControlBar`, `categoryPill`, `descriptionPill`, `playerButtons`, `submissionNotice`, `popupInitialised`, `lookupWaiting`, `loadedPreloadedSegment` | `getSkipButtonControlBar()`, `getCategoryPill()`, `getPopupInitialised()`, `setPopupInitialised()` |
| `videoListeners` | `lastCheckTime`, `lastCheckVideoTime` | `resetVideoListenerState()` |

`contentState` 从 35+ 字段缩减到 15 个真正需要跨模块共享的字段。

## 设计决策

- **共享状态对象** (`contentState`): 使用 getter/setter 代理模式，仅保留跨模块共享的核心数据
- **依赖注入**: 每个模块通过 `initXxx(deps)` 函数接收跨模块回调，解耦模块间的直接引用
- **模块重置函数**: 每个拥有私有状态的模块导出 `resetXxxState()` 函数，供 `content.ts` 的 `resetValues()` 调用
- **不修改 webpack 配置**: 入口仍为 `src/content.ts`，子模块通过 import 被自动打包
- **渐进式拆分**: 每个步骤独立可编译、可验证

## 验证

- ✅ `npm run build:dev:chrome` 编译通过
- ✅ `npm run test-without-building` 全部 53 个测试通过
- ✅ `npm run lint` 无新增错误

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d024e2f-ca0a-4865-8ced-f466638bfb4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d024e2f-ca0a-4865-8ced-f466638bfb4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

