### PR TITLE
Fix(thumbnail): Element selection error

### DIFF
--- a/src/thumbnail-utils/thumbnail-selectors.ts
+++ b/src/thumbnail-utils/thumbnail-selectors.ts
@@ -37,6 +37,7 @@ const thumbnailSelectors: { [key: string]: ThumbnailSelector } = {
         // 播放页推荐
         containerSelector: ".right-container",
         thumbnailSelector: ".video-page-card-small",
+        labelAnchorSelector: ".b-img img"
     },
     "listPlayerSideRecommendation": {
         // 列表播放页推荐


### PR DESCRIPTION
- [X] 我同意我的所有贡献将以GPL-3.0协议开源。

***
修复视频播放页卡片标签位置错位
<img width="780" height="447" alt="image" src="https://github.com/user-attachments/assets/0bc191f3-7765-4ab1-931c-1df58dd3c089" />
<img width="325" height="98" alt="image" src="https://github.com/user-attachments/assets/49423bbd-400f-4fbd-8c05-364b04a347a8" />

指定标签元素后
<img width="797" height="411" alt="image" src="https://github.com/user-attachments/assets/a4b0c67b-11bd-401c-a724-974424a1962c" />

***
另外该Bug在`0.11.3`表现为无法标记 是添加了什么兼容方法吗?